### PR TITLE
Fix runtime error in direct_message.select_guild

### DIFF
--- a/cogs/direct_message.py
+++ b/cogs/direct_message.py
@@ -202,8 +202,7 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
             "get_user_guilds", self.bot.cluster_count, {"user_id": message.author.id}
         )
         guilds = []
-        for chunk in data:
-            guilds.extend(chunk)
+        guilds.extend(data)
         guild_list = {}
         for guild in guilds:
             channels = [


### PR DESCRIPTION
# Summary
When running a freshly cloned instance of the bot, a `TypeError` occurs during the execution of `direct_message.select_guild`. This pull request fixes the issue detailed below.

Traceback:
```
Traceback (most recent call last):
  File "/home/yeet/.local/lib/python3.8/site-packages/discord/client.py", line 333, in _run_event
    await coro(*args, **kwargs)
  File "/home/yeet/modmail-repo/cogs/direct_message.py", line 366, in on_message
    await self.select_guild(message, prefix, msg)
  File "/home/yeet/modmail-repo/cogs/direct_message.py", line 206, in select_guild
    guilds.extend(chunk)
TypeError: 'DictToObj' object is not iterable
```

# Steps to reproduce
- Clone the repository (up to 6f4e9db at the time of writing)
- Deploy an instance of both Redis and PostgreSQL
- Create and restore a PostgreSQL database using `schema.sql`
- Follow configuration instructions (https://github.com/chamburr/modmail#configuration)
- Add the bot's account to any server and run `=setup`
- Send any direct message to the bot

# Expected Behavior
I was expecting a server selection prompt (as shown below) when sending a direct message to the bot.
![image](https://user-images.githubusercontent.com/29270534/97796367-2194f800-1bdf-11eb-9e5d-d40b74352245.png)
