### PR TITLE
Added Slash Commands Support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,5 @@ orjson==3.5.2
 psutil==5.8.0
 sentry-sdk==1.0.0
 subprocess32==3.5.4
+discord-py-slash-command==1.1.0
 git+git://github.com/Rapptz/discord.py@master


### PR DESCRIPTION
Added `discord-py-slash-command==1.1.0` in order to add Slash Commands to Modmail.