### PR TITLE
Clarify reason to login

### DIFF
--- a/utils/tools.py
+++ b/utils/tools.py
@@ -102,9 +102,8 @@ async def select_guild(bot, message, msg):
     user_guilds = await get_user_guilds(bot, message.author)
     if user_guilds is None:
         embed = Embed(
-            f"Please [click here]({bot.config.BASE_URI}/login?redirect=/authorized) to "
-            "login and allow the bot to see the servers you are in. " 
-            "This is required for the bot to function properly. "
+            f"Please [click here]({bot.config.BASE_URI}/login?redirect=/authorized) to verify. "
+            "This will allow the bot to see your servers and is required for the bot to function. "
             "Then, close the page and return back here."
         )
         await msg.edit(embed)

--- a/utils/tools.py
+++ b/utils/tools.py
@@ -102,7 +102,9 @@ async def select_guild(bot, message, msg):
     user_guilds = await get_user_guilds(bot, message.author)
     if user_guilds is None:
         embed = Embed(
-            f"Please [click here]({bot.config.BASE_URI}/login?redirect=/authorized) to login. "
+            f"Please [click here]({bot.config.BASE_URI}/login?redirect=/authorized) to "
+            "login and allow the bot to see the servers you are in. " 
+            "This is required for the bot to function properly. "
             "Then, close the page and return back here."
         )
         await msg.edit(embed)


### PR DESCRIPTION
**Summary**
Clarifies why users should login when they first encounter the login prompt in DMs. The hope is to alleviate some of the confusion since this is a non-standard thing for many bots and streamline the process by adding a brief description of why it is necessary by mentioning that this is required for the bot to function and providing a simple explanation.




