### PR TITLE
fix(bot): fix viewblacklist embed

### DIFF
--- a/cogs/core.py
+++ b/cogs/core.py
@@ -315,7 +315,7 @@ class Core(commands.Cog):
             all_pages.append(page)
 
         if len(all_pages) == 1:
-            embed = Embed(all_pages[0])
+            embed = all_pages[0]
             embed.set_footer(discord.Embed.Empty)
             await ctx.send(embed)
             return


### PR DESCRIPTION
**Summary**
Currently, when the blacklist is only one page, it sends an embed with the wrong content.

**Related issue(s)**
Provide links to relevant issues here.

**Additional context**
<img width="462" alt="CleanShot 2021-06-04 at 15 32 02@2x" src="https://user-images.githubusercontent.com/56286157/120763662-06f67900-c54a-11eb-8439-737ef2995b0d.png">

