### PR TITLE
Fix: modmail channels are visible to everyone

### DIFF
--- a/cogs/direct_message.py
+++ b/cogs/direct_message.py
@@ -73,13 +73,21 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
                 name = name + f"-{message.author.discriminator}"
             else:
                 name = message.author.id
-
+            async with self.bot.pool.acquire() as conn:
+                cursor = conn.cursor()
+                accessrole_id = int(await conn.fetchrow(
+                  "SELECT accessrole WHERE guild = $1",
+                (guild_id)))
             try:
                 channel = await guild.create_text_channel(
                     name=name,
                     category=category,
                     topic=f"ModMail Channel {message.author.id} {message.channel.id} (Please do "
                     "not change this)",
+                    overwrites = 
+                        guild.default_role: discord.PermissionOverwrite(view_channel=False),
+                        guild.get_role(accessrole_id): discord.PermissionOverwrite(view_channel=True,send_messages=True)
+                    }
                 )
             except discord.HTTPException as e:
                 await message.channel.send(


### PR DESCRIPTION
**Summary**
Fix a bug that Modmail channels are sometimes visible to everyone.


**Additional context**
In a server that I moderate, the modmail channels are visible to everyone in the server.
