### PR TITLE
#101 Adds reason to blacklist

### DIFF
--- a/cogs/direct_message.py
+++ b/cogs/direct_message.py
@@ -36,6 +36,8 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
             return
 
         data = await tools.get_data(self.bot, guild.id)
+        blocked = await tools.get_blocked(self.bot, member.id, guild.id)
+
 
         category = await guild.get_channel(data[2])
         if not category:
@@ -46,7 +48,7 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
             )
             return
 
-        if message.author.id in data[9]:
+        if message.author.id in data[9] or blocked[0]:
             await message.channel.send(
                 ErrorEmbed("That server has blacklisted you from sending a message there.")
             )

--- a/cogs/modmail_channel.py
+++ b/cogs/modmail_channel.py
@@ -43,8 +43,9 @@ class ModMailEvents(commands.Cog):
 
         data = await tools.get_data(self.bot, message.guild.id)
         user = tools.get_modmail_user(message.channel)
+        blocked = await tools.get_blocked(self.bot, message.author.id, message.guild.id)
 
-        if user.id in data[9]:
+        if user.id in data[9] or blocked[0]:
             await message.channel.send(
                 ErrorEmbed(
                     "That user is blacklisted from sending a message here. You need to whitelist "

--- a/schema.sql
+++ b/schema.sql
@@ -44,3 +44,12 @@ CREATE TABLE public.account
     token        text,
     PRIMARY KEY (identifier)
 );
+
+CREATE TABLE IF NOT EXISTS public.blocked
+(
+    member bigint NOT NULL,
+    guild bigint NOT NULL,
+    reason text COLLATE pg_catalog."default",
+    CONSTRAINT blocked_pkey PRIMARY KEY (member, guild)
+)
+

--- a/utils/tools.py
+++ b/utils/tools.py
@@ -195,6 +195,17 @@ async def get_data(bot, guild):
             False,
         )
 
+async def get_blocked(bot, member, guild):
+    async with bot.pool.acquire() as conn:
+        res = await conn.fetchrow("SELECT * FROM blocked WHERE member=$1 and guild=$2", member, guild)
+        if res:
+            return res
+
+        return await conn.fetchrow(
+            "INSERT INTO data VALUES ($1, $2, $3) RETURNING *",
+            member, guild, None
+        )
+
 
 async def get_guild_prefix(bot, guild):
     if not guild:


### PR DESCRIPTION
**Summary**
I updated the schemas.sql to add a `blocked` table which logs blocked member IDs, the guild their blocked from and the reason they were blocked.

I then updated core.py to accept a reason argument as part of the `blacklist` command. I updated the command to add in functionality of writing to the new `blocked` table however I kept in the old functionality for now. and .

I then subsequently updated direct_message.py, modmail_channel.py, and tools.py to be able to read the `blocked` table entries in any places it was already checking the blacklist entries of the data table.

Finally I updated core.py's `whitelist`  and `blacklistclear` commands to remove one and all entries respectively.

**Related issue(s)**
#101 Add a reason for blocking users

**Additional context**
Add any other context or screenshots about the pull request here.
