### PR TITLE
feat: Command only mode

### DIFF
--- a/cogs/configuration.py
+++ b/cogs/configuration.py
@@ -305,6 +305,36 @@ class Configuration(commands.Cog):
 
         await ctx.send(Embed("The channel is created successfully."))
 
+
+
+    @checks.in_database()
+    @checks.is_premium()
+    @commands.guild_only()
+    @checks.has_permissions(administrator=True)
+    @commands.command(
+        description="Toggle the bot to only send messages in a ticket if the `=reply` or `=areply` commands are used",
+        aliases=["commandonly"],
+        usage="commandrequired"
+    )
+    async def commandrequired(self,ctx):
+        data = await tools.get_data(self.bot, ctx.guild.id)
+
+        if data[12]:
+            async with self.bot.pool.acquire() as conn:
+                await conn.execute("UPDATE data SET commandrequired=$1 WHERE guild=$2",False,ctx.guild.id)
+
+            await ctx.send(Embed(f"Commands are no longer required to send messages"))
+            return
+
+        else:
+            async with self.bot.pool.acquire() as conn:
+                await conn.execute("UPDATE data SET commandrequired=$1 WHERE guild=$2",True,ctx.guild.id)
+
+            await ctx.send(Embed(f"Commands are now required to send messages."))
+            return
+
+
+
     @checks.in_database()
     @checks.is_premium()
     @checks.has_permissions(administrator=True)

--- a/cogs/configuration.py
+++ b/cogs/configuration.py
@@ -305,35 +305,27 @@ class Configuration(commands.Cog):
 
         await ctx.send(Embed("The channel is created successfully."))
 
-
-
     @checks.in_database()
-    @checks.is_premium()
-    @commands.guild_only()
     @checks.has_permissions(administrator=True)
+    @commands.guild_only()
     @commands.command(
-        description="Toggle the bot to only send messages in a ticket if the `=reply` or `=areply` commands are used",
-        aliases=["commandonly"],
-        usage="commandrequired"
+        description="Toggle whether commands are required to reply to a ticket.",
+        aliases=["commandrequired"],
+        usage="commandonly",
     )
-    async def commandrequired(self,ctx):
+    async def commandonly(self, ctx):
         data = await tools.get_data(self.bot, ctx.guild.id)
 
-        if data[12]:
-            async with self.bot.pool.acquire() as conn:
-                await conn.execute("UPDATE data SET commandrequired=$1 WHERE guild=$2",False,ctx.guild.id)
+        async with self.bot.pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE data SET commandonly=$1 WHERE guild=$2",
+                True if data[12] is False else False,
+                ctx.guild.id,
+            )
 
-            await ctx.send(Embed(f"Commands are no longer required to send messages"))
-            return
-
-        else:
-            async with self.bot.pool.acquire() as conn:
-                await conn.execute("UPDATE data SET commandrequired=$1 WHERE guild=$2",True,ctx.guild.id)
-
-            await ctx.send(Embed(f"Commands are now required to send messages."))
-            return
-
-
+        await ctx.send(
+            Embed(f"Command only mode is {'enabled' if data[12] is False else 'disabled'}.")
+        )
 
     @checks.in_database()
     @checks.is_premium()
@@ -454,9 +446,9 @@ class Configuration(commands.Cog):
         )
         embed.add_field("Advanced Logging", "Enabled" if data[7] is True else "Disabled")
         embed.add_field("Anonymous Messaging", "Enabled" if data[10] is True else "Disabled")
-        embed.add_field("Command Required Mode","Enabled" if data[12] is True else "Disabled")
+        embed.add_field("Command Only Mode","Enabled" if data[12] is True else "Disabled")
         embed.add_field("Greeting Message", "*Not set*" if greeting is None else greeting, False)
-        embed.add_field("Closing message", "*Not set*" if closing is None else closing, False)
+        embed.add_field("Closing Message", "*Not set*" if closing is None else closing, False)
 
         await ctx.send(embed)
 

--- a/cogs/configuration.py
+++ b/cogs/configuration.py
@@ -446,7 +446,7 @@ class Configuration(commands.Cog):
         )
         embed.add_field("Advanced Logging", "Enabled" if data[7] is True else "Disabled")
         embed.add_field("Anonymous Messaging", "Enabled" if data[10] is True else "Disabled")
-        embed.add_field("Command Only Mode","Enabled" if data[12] is True else "Disabled")
+        embed.add_field("Command Only Mode", "Enabled" if data[12] is True else "Disabled")
         embed.add_field("Greeting Message", "*Not set*" if greeting is None else greeting, False)
         embed.add_field("Closing Message", "*Not set*" if closing is None else closing, False)
 

--- a/cogs/configuration.py
+++ b/cogs/configuration.py
@@ -319,12 +319,12 @@ class Configuration(commands.Cog):
         async with self.bot.pool.acquire() as conn:
             await conn.execute(
                 "UPDATE data SET commandonly=$1 WHERE guild=$2",
-                True if data[12] is False else False,
+                True if data[11] is False else False,
                 ctx.guild.id,
             )
 
         await ctx.send(
-            Embed(f"Command only mode is {'enabled' if data[12] is False else 'disabled'}.")
+            Embed(f"Command only mode is {'enabled' if data[11] is False else 'disabled'}.")
         )
 
     @checks.in_database()
@@ -446,7 +446,7 @@ class Configuration(commands.Cog):
         )
         embed.add_field("Advanced Logging", "Enabled" if data[7] is True else "Disabled")
         embed.add_field("Anonymous Messaging", "Enabled" if data[10] is True else "Disabled")
-        embed.add_field("Command Only Mode", "Enabled" if data[12] is True else "Disabled")
+        embed.add_field("Command Only Mode", "Enabled" if data[11] is True else "Disabled")
         embed.add_field("Greeting Message", "*Not set*" if greeting is None else greeting, False)
         embed.add_field("Closing Message", "*Not set*" if closing is None else closing, False)
 

--- a/cogs/configuration.py
+++ b/cogs/configuration.py
@@ -454,6 +454,7 @@ class Configuration(commands.Cog):
         )
         embed.add_field("Advanced Logging", "Enabled" if data[7] is True else "Disabled")
         embed.add_field("Anonymous Messaging", "Enabled" if data[10] is True else "Disabled")
+        embed.add_field("Command Required Mode","Enabled" if data[12] is True else "Disabled")
         embed.add_field("Greeting Message", "*Not set*" if greeting is None else greeting, False)
         embed.add_field("Closing message", "*Not set*" if closing is None else closing, False)
 

--- a/cogs/direct_message.py
+++ b/cogs/direct_message.py
@@ -117,10 +117,14 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
                 f"`{prefix}close [reason]` to close this ticket.",
                 timestamp=True,
             )
+
             if data[12]:
-                embed.add_field("Command Required Mode",
-                "Command Required Mode is enabled for this server. To send a message, you must use "
-                f"`{prefix}reply` or `{prefix}areply`. All other messages sent will be ignored.")
+                embed.description = (
+                    f"Type `{prefix}reply <message>` in this channel to reply. All other messages"
+                    "are ignored, and can be used for staff discussion. Use the command "
+                    f"`{prefix}close [reason]` to close this ticket. (Command only mode enabled)"
+                )
+
             embed.add_field("User", f"<@{message.author.id}> ({message.author.id})")
             embed.add_field(
                 "Roles",

--- a/cogs/direct_message.py
+++ b/cogs/direct_message.py
@@ -118,7 +118,7 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
                 timestamp=True,
             )
 
-            if data[12]:
+            if data[11]:
                 embed.description = (
                     f"Type `{prefix}reply <message>` in this channel to reply. All other messages"
                     "are ignored, and can be used for staff discussion. Use the command "

--- a/cogs/direct_message.py
+++ b/cogs/direct_message.py
@@ -120,7 +120,7 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
 
             if data[11]:
                 embed.description = (
-                    f"Type `{prefix}reply <message>` in this channel to reply. All other messages"
+                    f"Type `{prefix}reply <message>` in this channel to reply. All other messages "
                     "are ignored, and can be used for staff discussion. Use the command "
                     f"`{prefix}close [reason]` to close this ticket. (Command only mode enabled)"
                 )

--- a/cogs/direct_message.py
+++ b/cogs/direct_message.py
@@ -117,6 +117,10 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
                 f"`{prefix}close [reason]` to close this ticket.",
                 timestamp=True,
             )
+            if data[12]:
+                embed.add_field("Command Required Mode",
+                "Command Required Mode is enabled for this server. To send a message, you must use "
+                f"`{prefix}reply` or `{prefix}areply`. All other messages sent will be ignored.")
             embed.add_field("User", f"<@{message.author.id}> ({message.author.id})")
             embed.add_field(
                 "Roles",

--- a/cogs/modmail_channel.py
+++ b/cogs/modmail_channel.py
@@ -24,9 +24,17 @@ class ModMailEvents(commands.Cog):
         if permissions.send_messages is False or permissions.embed_links is False:
             return
 
-        prefix = await tools.get_guild_prefix(self.bot, message.guild)
-        if message.content.startswith(prefix):
+        data = await tools.get_data(self.bot, message.guild.id)
+
+        
+        # If =reply or =areply is required, return
+        if data[12]:
             return
+
+        else:
+            prefix = await tools.get_guild_prefix(self.bot, message.guild)
+            if message.content.startswith(prefix):
+                return
 
         if await tools.is_user_banned(self.bot, message.author):
             await message.channel.send(ErrorEmbed("You are banned from this bot."))

--- a/cogs/modmail_channel.py
+++ b/cogs/modmail_channel.py
@@ -24,22 +24,20 @@ class ModMailEvents(commands.Cog):
         if permissions.send_messages is False or permissions.embed_links is False:
             return
 
-        data = await tools.get_data(self.bot, message.guild.id)
+        prefix = await tools.get_guild_prefix(self.bot, message.guild)
+        if message.content.startswith(prefix):
+            return
 
+        data = await tools.get_data(self.bot, message.guild.id)
         # If =reply or =areply is required, return
         if data[11]:
             return
 
-        else:
-            prefix = await tools.get_guild_prefix(self.bot, message.guild)
-            if message.content.startswith(prefix):
-                return
-
-        if await tools.is_user_banned(self.bot, message.author):
+        elif await tools.is_user_banned(self.bot, message.author):
             await message.channel.send(ErrorEmbed("You are banned from this bot."))
             return
 
-        if (await tools.get_data(self.bot, message.guild.id))[10] is True:
+        elif data[10] is True:
             await self.send_mail_mod(message, prefix, anon=True)
             return
 

--- a/cogs/modmail_channel.py
+++ b/cogs/modmail_channel.py
@@ -27,7 +27,7 @@ class ModMailEvents(commands.Cog):
         data = await tools.get_data(self.bot, message.guild.id)
 
         # If =reply or =areply is required, return
-        if data[12]:
+        if data[11]:
             return
 
         else:

--- a/cogs/modmail_channel.py
+++ b/cogs/modmail_channel.py
@@ -26,7 +26,6 @@ class ModMailEvents(commands.Cog):
 
         data = await tools.get_data(self.bot, message.guild.id)
 
-        
         # If =reply or =areply is required, return
         if data[12]:
             return

--- a/cogs/modmail_channel.py
+++ b/cogs/modmail_channel.py
@@ -29,15 +29,14 @@ class ModMailEvents(commands.Cog):
             return
 
         data = await tools.get_data(self.bot, message.guild.id)
-        # If =reply or =areply is required, return
-        if data[11]:
+        if data[11] is True:
             return
 
-        elif await tools.is_user_banned(self.bot, message.author):
+        if await tools.is_user_banned(self.bot, message.author):
             await message.channel.send(ErrorEmbed("You are banned from this bot."))
             return
 
-        elif data[10] is True:
+        if data[10] is True:
             await self.send_mail_mod(message, prefix, anon=True)
             return
 

--- a/schema.sql
+++ b/schema.sql
@@ -11,6 +11,7 @@ CREATE TABLE public.data
     pingrole    bigint[] NOT NULL,
     blacklist   bigint[] NOT NULL,
     anonymous   boolean  NOT NULL,
+    commandrequired boolean NOT NULL default False,
     PRIMARY KEY (guild)
 );
 

--- a/schema.sql
+++ b/schema.sql
@@ -11,7 +11,7 @@ CREATE TABLE public.data
     pingrole    bigint[] NOT NULL,
     blacklist   bigint[] NOT NULL,
     anonymous   boolean  NOT NULL,
-    commandrequired boolean NOT NULL default False,
+    commandonly boolean  NOT NULL,
     PRIMARY KEY (guild)
 );
 

--- a/utils/tools.py
+++ b/utils/tools.py
@@ -181,7 +181,7 @@ async def get_data(bot, guild):
             return res
 
         return await conn.fetchrow(
-            "INSERT INTO data VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) RETURNING *",
+            "INSERT INTO data VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12) RETURNING *",
             guild,
             None,
             None,
@@ -192,6 +192,7 @@ async def get_data(bot, guild):
             False,
             [],
             [],
+            False,
             False,
         )
 

--- a/web/content/commands.md
+++ b/web/content/commands.md
@@ -37,10 +37,11 @@ Toggle between enable and disable for ModMail logs.
 
 - Alias: logs
   
-## commandrequired
-Toggle between commands being required to send messages in a ticket
+## commandonly
 
-- Alias: commandonly
+Toggle whether commands are required to reply to a ticket.
+
+- Alias: commandrequired
 
 ## greetingmessage
 

--- a/web/content/commands.md
+++ b/web/content/commands.md
@@ -36,6 +36,11 @@ Set or clear the roles mentioned when a ticket is opened. You can also use `ever
 Toggle between enable and disable for ModMail logs.
 
 - Alias: logs
+  
+## commandrequired
+Toggle between commands being required to send messages in a ticket
+
+- Alias: commandonly
 
 ## greetingmessage
 


### PR DESCRIPTION
**Summary**
Adds a command which will enable servers to set a `command only` mode on tickets, where either the `=reply` or `=areply` commands are required to send a response in a ticket.

**Related issue(s)**
Issue #99 

