### PR TITLE
Removes unnecessary reactions and footer in server list

### DIFF
--- a/utils/tools.py
+++ b/utils/tools.py
@@ -139,14 +139,16 @@ async def select_guild(bot, message, msg):
 
     embeds = []
 
-    for chunk in [list(guilds.items())[i : i + 9] for i in range(0, len(guilds), 9)]:
+    for chunk in [list(guilds.items())[i : i + 10] for i in range(0, len(guilds), 10)]:
         embed = Embed(
             "Select Server",
             "Please select the server you want to send this message to. You can do so by reacting "
             "with the corresponding emote.",
         )
-        if len(guilds) > 9:
+
+        if len(guilds) > 10:
             embed.set_footer("Use the reactions to flip pages.")
+
         for guild, value in chunk:
             embed.add_field(
                 f"{len(embed.fields) + 1}: {value[0]}",
@@ -158,10 +160,11 @@ async def select_guild(bot, message, msg):
 
     await msg.edit(embeds[0])
 
-    if len(guilds) > 9:
+    if len(guilds) > 10:
         await msg.add_reaction("◀️")
         await msg.add_reaction("▶️")
-    for reaction in ["1⃣", "2⃣", "3⃣", "4⃣", "5⃣", "6⃣", "7⃣", "8⃣", "9⃣",][
+
+    for reaction in ["1⃣", "2⃣", "3⃣", "4⃣", "5⃣", "6⃣", "7⃣", "8⃣", "9⃣", "🔟"][
         : len(embeds[0].fields)
     ]:
         await msg.add_reaction(reaction)

--- a/utils/tools.py
+++ b/utils/tools.py
@@ -139,14 +139,14 @@ async def select_guild(bot, message, msg):
 
     embeds = []
 
-    for chunk in [list(guilds.items())[i : i + 10] for i in range(0, len(guilds), 10)]:
+    for chunk in [list(guilds.items())[i : i + 9] for i in range(0, len(guilds), 9)]:
         embed = Embed(
             "Select Server",
             "Please select the server you want to send this message to. You can do so by reacting "
             "with the corresponding emote.",
         )
-        embed.set_footer("Use the reactions to flip pages.")
-
+        if len(guilds) > 9:
+            embed.set_footer("Use the reactions to flip pages.")
         for guild, value in chunk:
             embed.add_field(
                 f"{len(embed.fields) + 1}: {value[0]}",
@@ -158,9 +158,10 @@ async def select_guild(bot, message, msg):
 
     await msg.edit(embeds[0])
 
-    await msg.add_reaction("◀️")
-    await msg.add_reaction("▶️")
-    for reaction in ["1⃣", "2⃣", "3⃣", "4⃣", "5⃣", "6⃣", "7⃣", "8⃣", "9⃣", "🔟"][
+    if len(guilds) > 9:
+        await msg.add_reaction("◀️")
+        await msg.add_reaction("▶️")
+    for reaction in ["1⃣", "2⃣", "3⃣", "4⃣", "5⃣", "6⃣", "7⃣", "8⃣", "9⃣",][
         : len(embeds[0].fields)
     ]:
         await msg.add_reaction(reaction)


### PR DESCRIPTION
**Summary**
I updated tools.py to adjust how many servers it shows per page from **10** to **9** to be more aesthetically pleasing (come on you can't say 3x3+1 looks better than 3x3).

I then updated the embed footer to put it behind ` if len(guilds) > 9:` so that the footer message only shows if there is more than 9 servers and then I did the same for the `await msg.add_reaction("◀️")` and `await msg.add_reaction("▶️")` so that those reactions don't show unless there are more than 9 servers.

**Related issue(s)**
#103 Remove Paginator when not needed

**Additional context**
This branch (should) remedy my dual commit PR #117 