### PR TITLE
Updated READ.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ModMail
 
-[![Discord](https://discordapp.com/api/guilds/576016832956334080/embed.png)](https://discord.gg/wjWJwJB)
-[![License](https://img.shields.io/github/license/chamburr/modmail.svg)](https://github.com/chamburr/modmail/blob/master/LICENSE)
+[![Discord](https://discord.com/api/guilds/576016832956334080/widget.png)][discord]
+[![License](https://img.shields.io/github/license/chamburr/modmail.svg)](LICENSE)
 
 A feature-rich Discord bot for easy communication between server staff and users.
 
@@ -10,8 +10,7 @@ A feature-rich Discord bot for easy communication between server staff and users
 A new channel is created whenever a user messages the bot, and the channel will serve as a shared
 inbox for seamless communication between staff and the user.
 
-To learn more, check out our [website](https://modmail.xyz) or visit
-our [Discord server](https://discord.gg/wjWJwJB).
+To learn more, check out our [website](https://modmail.xyz) or visit our [Discord server][discord].
 
 ## Contributing
 
@@ -21,21 +20,21 @@ There are many ways you can contribute to this project:
 - [Reviewing pull requests](https://github.com/chamburr/modmail/pulls)
 - [Contribute directly to the code base](https://github.com/chamburr/modmail/pulls)
 
-For more information, please see
-our [contributing guidelines](https://github.com/chamburr/modmail/blob/master/CONTRIBUTING.md).
+For more information, please see our [contributing guidelines](CONTRIBUTING.md).
 
 The issue tracker here is only for bug reports and suggestions. Please do not use it to ask a
-question. Instead, ask it on our [Discord server](https://discord.gg/wjWJwJB).
+question. Instead, ask it on our [Discord server][discord].
 
 ## Self-hosting
 
 Due to the complex infrastructure, the bot is unfortunately not suitable to for self-hosting at the
 moment. Please use our public instance while we are working on a way to run the bot with Docker.
 
-Alternatively, you may also host [v2.x](https://github.com/chamburr/modmail/tree/v2.1.2) of this bot. There are self-hosting instructions on the [README](https://github.com/chamburr/modmail/tree/v2.1.2#self-hosting) page of those versions.
+Alternatively, you may also host [v2.x](https://github.com/chamburr/modmail/tree/v2.1.2) of this
+bot. There are self-hosting instructions on the README page of those versions.
 
 ## License
 
-This project is licensed
-under [GNU Affero General Public License v3.0](https://github.com/chamburr/modmail/blob/master/LICENSE)
-.
+This project is licensed under [GNU Affero General Public License v3.0](LICENSE).
+
+[discord]: https://discord.gg/wjWJwJB

--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ question. Instead, ask it on our [Discord server](https://discord.gg/wjWJwJB).
 Due to the complex infrastructure, the bot is unfortunately not suitable to for self-hosting at the
 moment. Please use our public instance while we are working on a way to run the bot with Docker.
 
-Alternatively, you may also host v2.x of this bot. There are self-hosting instructions on the README
-page of those versions.
+Alternatively, you may also host [v2.x](https://github.com/chamburr/modmail/tree/v2.1.2) of this bot. There are self-hosting instructions on the [README](https://github.com/chamburr/modmail/tree/v2.1.2#self-hosting) page of those versions.
 
 ## License
 


### PR DESCRIPTION
**Summary**
Updated READ.md to include links to V2.x of the bot and its specific self-hosting section of the READ.md

**Related issue(s)**
N/A

**Additional context**
PR'd this change for better UX for users looking to self-host, jumping through the tag's history to find V2, although not difficult, can be confusing especially for new users.