### PR TITLE
feat:combine closing messages

### DIFF
--- a/cogs/core.py
+++ b/cogs/core.py
@@ -74,17 +74,22 @@ class Core(commands.Cog):
             dm_channel = tools.get_modmail_channel(self.bot, ctx.channel)
 
             if data[6]:
-                embed2 = Embed(
-                    "Closing Message",
-                    tools.tag_format(data[6], member),
-                    colour=0xFF4500,
-                    timestamp=True,
-                )
-                embed2.set_footer(f"{ctx.guild.name} | {ctx.guild.id}", ctx.guild.icon_url)
-                try:
-                    await dm_channel.send(embed2)
-                except discord.Forbidden:
-                    pass
+                # If the reason was not set, then add the automatic closing message 
+                # To the "Ticket Closed" embed. Otherwise send two messages
+                if reason is None:
+                    embed.description = tools.tag_format(data[6],member)
+                else:
+                    embed2 = Embed(
+                        "Closing Message",
+                        tools.tag_format(data[6], member),
+                        colour=0xFF4500,
+                        timestamp=True,
+                    )
+                    embed2.set_footer(f"{ctx.guild.name} | {ctx.guild.id}", ctx.guild.icon_url)
+                    try:
+                        await dm_channel.send(embed2)
+                    except discord.Forbidden:
+                        pass
 
             try:
                 await dm_channel.send(embed)


### PR DESCRIPTION
Implements issue #130

Adds a simple check when closing a ticket. If the reason passed in is `None`, then do not send the embed with the title `Closing Message`, just add the closing snippet to the existing `Ticket Closed` embed.

I would want to edit the title of the embed to make the person who receives the message aware if the reason for closing the ticket was sent automatically or was written by a person. My two ideas are to either:
- Change "Closing Message" to be "Automatic Closing Message"
- In `tools.tag_format` add a line that says "This message was sent automatically when the ticket was closed" before the actual message.

I think option 2 is the better option for readability for users, but thoughts are welcome.
