### PR TITLE
fix(bot): Fix logging command

### DIFF
--- a/cogs/configuration.py
+++ b/cogs/configuration.py
@@ -271,6 +271,7 @@ class Configuration(commands.Cog):
     )
     async def logging(self, ctx, channel: typing.Optional[ChannelConverter]):
         data = await tools.get_data(self.bot, ctx.guild.id)
+
         if channel is not None:
             async with self.bot.pool.acquire() as conn:
                 await conn.execute(

--- a/cogs/configuration.py
+++ b/cogs/configuration.py
@@ -269,14 +269,14 @@ class Configuration(commands.Cog):
         aliases=["logs"],
         usage="logging [channel]",
     )
-    async def logging(self, ctx, channel: typing.Optional[ChannelConverter] = None):
+    async def logging(self, ctx, channel: typing.Optional[ChannelConverter]):
         data = await tools.get_data(self.bot, ctx.guild.id)
         if channel is not None:
             async with self.bot.pool.acquire() as conn:
-            await conn.execute(
-                "UPDATE data SET logging=$1 WHERE guild=$2", channel.id, ctx.guild.id
-            )
-            await ctx.send(Embed("The logging channel has been changed"))
+                await conn.execute(
+                    "UPDATE data SET logging=$1 WHERE guild=$2", channel.id, ctx.guild.id
+                )
+            await ctx.send(Embed("Logging channel is changed."))
             return
             
         if data[4]:
@@ -296,8 +296,8 @@ class Configuration(commands.Cog):
             )
             return
 
-        
         channel = await ctx.guild.create_text_channel(name="modmail-log", category=category)
+
         async with self.bot.pool.acquire() as conn:
             await conn.execute(
                 "UPDATE data SET logging=$1 WHERE guild=$2", channel.id, ctx.guild.id

--- a/cogs/configuration.py
+++ b/cogs/configuration.py
@@ -271,16 +271,8 @@ class Configuration(commands.Cog):
     )
     async def logging(self, ctx, channel: typing.Optional[ChannelConverter]):
         data = await tools.get_data(self.bot, ctx.guild.id)
-
-        if channel is not None:
-            async with self.bot.pool.acquire() as conn:
-                await conn.execute(
-                    "UPDATE data SET logging=$1 WHERE guild=$2", channel.id, ctx.guild.id
-                )
-            await ctx.send(Embed("Logging channel is changed."))
-            return
             
-        if data[4]:
+        if data[4] and channel is None:
             async with self.bot.pool.acquire() as conn:
                 await conn.execute("UPDATE data SET logging=$1 WHERE guild=$2", None, ctx.guild.id)
 
@@ -297,7 +289,8 @@ class Configuration(commands.Cog):
             )
             return
 
-        channel = await ctx.guild.create_text_channel(name="modmail-log", category=category)
+        if channel is None:
+            channel = await ctx.guild.create_text_channel(name="modmail-log", category=category)
 
         async with self.bot.pool.acquire() as conn:
             await conn.execute(

--- a/cogs/configuration.py
+++ b/cogs/configuration.py
@@ -271,7 +271,7 @@ class Configuration(commands.Cog):
     )
     async def logging(self, ctx, channel: typing.Optional[ChannelConverter]):
         data = await tools.get_data(self.bot, ctx.guild.id)
-            
+
         if data[4] and channel is None:
             async with self.bot.pool.acquire() as conn:
                 await conn.execute("UPDATE data SET logging=$1 WHERE guild=$2", None, ctx.guild.id)


### PR DESCRIPTION
If a user specifies any channel, then the bot should switch the logging channel to that one before disabling the logging functionality. If no channel is specified, then the command will work like a toggle: disable logging if enabled, and create a logging command if disabled already.

see #bug-report in discord for more info

