### PR TITLE
Clarifies error message when modmail category is at maximum channels

### DIFF
--- a/cogs/direct_message.py
+++ b/cogs/direct_message.py
@@ -99,6 +99,14 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
                         topic=f"ModMail Channel {message.author.id} {message.channel.id} (Please "
                         "do not change this)",
                     )
+                elif "Maximum number of channels in category reached" in e.text:
+                    await message.channel.send(
+                        ErrorEmbed(
+                            "The server has reached the maximum number of active tickets. Please "
+                            "try again later."
+                        )
+                    )
+                    return
                 else:
                     await message.channel.send(
                         ErrorEmbed(

--- a/cogs/direct_message.py
+++ b/cogs/direct_message.py
@@ -99,7 +99,7 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
                         topic=f"ModMail Channel {message.author.id} {message.channel.id} (Please "
                         "do not change this)",
                     )
-                elif "Maximum number of channels in category reached" in e.text:
+                elif "Maximum number of channels" in e.text:
                     await message.channel.send(
                         ErrorEmbed(
                             "The server has reached the maximum number of active tickets. Please "


### PR DESCRIPTION
**Summary**
This error message is common and unclear, it appears as the following:
![image](https://user-images.githubusercontent.com/22421329/231499814-f05128f7-060e-423c-923e-6daee9c43f47.png)

Many users are unable to determine that they should wait for some issues to be cleared up and then reattempt their message. This change hopefully sheds light on this course of action by changing the error message to be in more clear language.

**Related issue(s)**
None

**Additional context**
None
