### PR TITLE
Update premium.vue

### DIFF
--- a/web/pages/premium.vue
+++ b/web/pages/premium.vue
@@ -17,6 +17,13 @@
         </Card>
       </div>
     </div>
+    <div class="text-left mt-5 pt-4">
+      <p class="h5">Importnat Notice</p>
+      <p>
+        You must join the support server before making your purchase, as the role Modmail
+        grants you on the support server is required to use the premium features.
+      </p>
+    </div>
     <div class="row mt-4 text-center justify-content-around">
       <div class="col-lg-1"></div>
       <div class="col-12 col-md-4 col-lg-3 mb-4 px-2 my-md-auto">


### PR DESCRIPTION
**Summary**
- Remove James' discriminator
- Add an informational warning informing people they need to join the support server before purchasing otherwise they will not be getting the role which is required for the premium features.

**Related issue(s)**
None

**Additional context**
Discord removed discriminators a while back (which I still don't disagree with) and so you can no longer refer to James by name#discrim but the website had not been updated with this change.
I also felt the website should have a warning about joining the support server before purchasing.
