### PR TITLE
chore: Update About Us Page

### DIFF
--- a/web/content/about.md
+++ b/web/content/about.md
@@ -2,72 +2,63 @@
 
 Developer, Administrator
 
-- Image: https://cdn.discordapp.com/avatars/446290930723717120/a23dcacf8b9d10dd3f3ebced4e5f7ffd.png
+- Image: https://i.ibb.co/6Y5WbQv/chamburr-avatar.png
 - Website: https://chamburr.com
 - GitHub: https://github.com/chamburr
 - Twitter: https://twitter.com/chamburr22
 - Reddit: https://www.reddit.com/user/chamburr22
 - LinkedIn: https://linkedin.com/in/chamburr
 
-# Foxtrek_64
-
-Administrator
-
-- Image: https://cdn.discordapp.com/avatars/197291773133979648/a48b8b5fee8d571e06d024cb05d2d4f9.png
-- GitHub: https://github.com/Foxtrek64
-
 # James [a_leon]
 
 Administrator
 
-- Image: https://cdn.discordapp.com/avatars/381998065327931392/fe36746e200371a22f8d8974e3d8a2f4.png
+- Image: https://i.ibb.co/gWvb8jv/james-avatar.png
 - GitHub: https://github.com/jrwallor
 - Twitter: https://twitter.com/jrwallor
 
-# dyl
-
-Moderator
-
-- Image: https://cdn.discordapp.com/avatars/332314562575597579/fcdda2edf76c496bc7327f8697cd84b0.png
-- GitHub: https://github.com/dlsnyder8
-
-# Mikhail
-
-Moderator
-
-- Image: https://cdn.discordapp.com/avatars/247151607647698947/245779119e94951967f5a87a657416cc.png
-
-# Shadowstar
-
-Moderator
-
-- Image: https://cdn.discordapp.com/avatars/433276300703170580/7a83b60a5f14d6375a99fcbca10381c9.png
-- GitHub: https://github.com/ShadowstarUnited
-- Twitter: https://twitter.com/Shadowstardark
-- Reddit: https://www.reddit.com/user/ShadowstarUnited
-
 # SnowyJaguar
 
-Moderator
+Administrator
 
-- Image: https://cdn.discordapp.com/avatars/365262543872327681/d988966ec87afc03de6a648ace4cca6d.png
+- Image: https://i.ibb.co/vQN3xTh/snowyjaguar-avatar.png
 - Website: https://teagancollyer.wordpress.com
 - GitHub: https://github.com/SnowyJaguar1034
 - Twitter: https://twitter.com/SnowyJaguar1034
 - Reddit: https://www.reddit.com/user/NinthTurtle1034
 - LinkedIn: https://www.linkedin.com/in/teagancollyer
 
-# FlareonIsCute
 
-Support
+# Mikhail
 
-- Image: https://cdn.discordapp.com/avatars/488283878189039626/6b9a118b7c6933ab61c88d5661f827c3.png
-- GitHub: https://github.com/shus2307
-- Reddit: https://www.reddit.com/user/flareonthecutest
+Moderator
+
+- Image: https://i.ibb.co/xzYMkBy/mikhail-avatar.png
+
+# Jordan
+
+Moderator
+
+- Image: https://i.ibb.co/2cPnww3/jordan-avatar.jpg
+
 
 # waterflamev8
 
 Support
 
-- Image: https://cdn.discordapp.com/avatars/723794074498367498/04ef2c02bd3341e42bda2ec5d6d2dcd2.png
+- Image: https://i.ibb.co/C28qqzG/waterflamev8-avatar.png
 - GitHub: https://github.com/waterflamev8
+
+
+# Agent Bunny in Space
+
+Support
+
+- Image: https://i.ibb.co/VBGNHKY/agent-bunny-avatar.png
+
+# dyl
+
+Contributor
+
+- Image: https://cdn.discordapp.com/avatars/332314562575597579/fcdda2edf76c496bc7327f8697cd84b0.png
+- GitHub: https://github.com/dlsnyder8

--- a/web/content/about.md
+++ b/web/content/about.md
@@ -2,7 +2,7 @@
 
 Developer, Administrator
 
-- Image: https://i.ibb.co/6Y5WbQv/chamburr-avatar.png
+- Image: https://github.com/chamburr/modmail/assets/51924672/0001f97f-b1da-493c-a297-6b9eb9975e48
 - Website: https://chamburr.com
 - GitHub: https://github.com/chamburr
 - Twitter: https://twitter.com/chamburr22
@@ -13,7 +13,7 @@ Developer, Administrator
 
 Administrator
 
-- Image: https://i.ibb.co/gWvb8jv/james-avatar.png
+- Image: https://github.com/chamburr/modmail/assets/51924672/eb96bc49-4736-4fe4-99ab-ffa8d1148f1c
 - GitHub: https://github.com/jrwallor
 - Twitter: https://twitter.com/jrwallor
 
@@ -21,7 +21,7 @@ Administrator
 
 Administrator
 
-- Image: https://i.ibb.co/vQN3xTh/snowyjaguar-avatar.png
+- Image: https://github.com/chamburr/modmail/assets/51924672/a0f6712d-8922-47b1-be99-f654813b4c3a
 - Website: https://teagancollyer.wordpress.com
 - GitHub: https://github.com/SnowyJaguar1034
 - Twitter: https://twitter.com/SnowyJaguar1034
@@ -33,20 +33,20 @@ Administrator
 
 Moderator
 
-- Image: https://i.ibb.co/xzYMkBy/mikhail-avatar.png
+- Image: https://github.com/chamburr/modmail/assets/51924672/6d7b0c7c-af05-4d87-a713-6dea8a650fbd
 
 # Jordan
 
 Moderator
 
-- Image: https://i.ibb.co/2cPnww3/jordan-avatar.jpg
+- Image: https://github.com/chamburr/modmail/assets/51924672/3e99d79f-58ee-4425-b3b4-d6d763e0dea7
 
 
 # waterflamev8
 
 Support
 
-- Image: https://i.ibb.co/C28qqzG/waterflamev8-avatar.png
+- Image: https://github.com/chamburr/modmail/assets/51924672/2c6104d1-04b7-4bdc-b798-e0e2d7417a0f
 - GitHub: https://github.com/waterflamev8
 
 
@@ -54,11 +54,11 @@ Support
 
 Support
 
-- Image: https://i.ibb.co/VBGNHKY/agent-bunny-avatar.png
+- Image: https://github.com/chamburr/modmail/assets/51924672/2dfec846-10a2-4680-8638-7c3dbd82bcd6
 
 # dyl
 
 Contributor
 
-- Image: https://cdn.discordapp.com/avatars/332314562575597579/fcdda2edf76c496bc7327f8697cd84b0.png
+- Image: https://github.com/chamburr/modmail/assets/51924672/ff772da4-b9f6-44ba-9b77-11d29e1f2886
 - GitHub: https://github.com/dlsnyder8

--- a/web/content/about.md
+++ b/web/content/about.md
@@ -28,6 +28,11 @@ Administrator
 - Reddit: https://www.reddit.com/user/NinthTurtle1034
 - LinkedIn: https://www.linkedin.com/in/teagancollyer
 
+# Jordan
+
+Moderator
+
+- Image: https://github.com/chamburr/modmail/assets/51924672/f9df2de1-8dd2-4f61-a147-e74ac066dfd1
 
 # Mikhail
 
@@ -35,12 +40,11 @@ Moderator
 
 - Image: https://github.com/chamburr/modmail/assets/51924672/8b599a3b-44b4-4170-940e-180056f7c11b
 
-# Jordan
+# Agent Bunny in Space
 
-Moderator
+Support
 
-- Image: https://github.com/chamburr/modmail/assets/51924672/f9df2de1-8dd2-4f61-a147-e74ac066dfd1
-
+- Image: https://github.com/chamburr/modmail/assets/51924672/ea63fa67-b402-48b6-81fa-d773440a386e
 
 # waterflamev8
 
@@ -48,13 +52,6 @@ Support, Contributor
 
 - Image: https://github.com/chamburr/modmail/assets/51924672/31b08ac3-5a45-4a73-bfdc-12266349e140
 - GitHub: https://github.com/waterflamev8
-
-
-# Agent Bunny in Space
-
-Support
-
-- Image: https://github.com/chamburr/modmail/assets/51924672/ea63fa67-b402-48b6-81fa-d773440a386e
 
 # dyl
 

--- a/web/content/about.md
+++ b/web/content/about.md
@@ -2,7 +2,7 @@
 
 Developer, Administrator
 
-- Image: https://github.com/chamburr/modmail/assets/51924672/0001f97f-b1da-493c-a297-6b9eb9975e48
+- Image: https://github.com/chamburr/modmail/assets/51924672/18a0dcb8-5f97-4a5d-b4dc-9c3ad5ef7a8a
 - Website: https://chamburr.com
 - GitHub: https://github.com/chamburr
 - Twitter: https://twitter.com/chamburr22
@@ -13,7 +13,7 @@ Developer, Administrator
 
 Administrator
 
-- Image: https://github.com/chamburr/modmail/assets/51924672/eb96bc49-4736-4fe4-99ab-ffa8d1148f1c
+- Image: https://github.com/chamburr/modmail/assets/51924672/7019a9f1-21bf-49cb-891a-fe63503e8096
 - GitHub: https://github.com/jrwallor
 - Twitter: https://twitter.com/jrwallor
 
@@ -21,7 +21,7 @@ Administrator
 
 Administrator
 
-- Image: https://github.com/chamburr/modmail/assets/51924672/a0f6712d-8922-47b1-be99-f654813b4c3a
+- Image: https://github.com/chamburr/modmail/assets/51924672/3d99ba37-dc10-4ac9-85eb-9a3bef176529
 - Website: https://teagancollyer.wordpress.com
 - GitHub: https://github.com/SnowyJaguar1034
 - Twitter: https://twitter.com/SnowyJaguar1034
@@ -33,20 +33,20 @@ Administrator
 
 Moderator
 
-- Image: https://github.com/chamburr/modmail/assets/51924672/6d7b0c7c-af05-4d87-a713-6dea8a650fbd
+- Image: https://github.com/chamburr/modmail/assets/51924672/8b599a3b-44b4-4170-940e-180056f7c11b
 
 # Jordan
 
 Moderator
 
-- Image: https://github.com/chamburr/modmail/assets/51924672/3e99d79f-58ee-4425-b3b4-d6d763e0dea7
+- Image: https://github.com/chamburr/modmail/assets/51924672/f9df2de1-8dd2-4f61-a147-e74ac066dfd1
 
 
 # waterflamev8
 
-Support
+Support, Contributor
 
-- Image: https://github.com/chamburr/modmail/assets/51924672/2c6104d1-04b7-4bdc-b798-e0e2d7417a0f
+- Image: https://github.com/chamburr/modmail/assets/51924672/31b08ac3-5a45-4a73-bfdc-12266349e140
 - GitHub: https://github.com/waterflamev8
 
 
@@ -54,7 +54,7 @@ Support
 
 Support
 
-- Image: https://github.com/chamburr/modmail/assets/51924672/2dfec846-10a2-4680-8638-7c3dbd82bcd6
+- Image: https://github.com/chamburr/modmail/assets/51924672/ea63fa67-b402-48b6-81fa-d773440a386e
 
 # dyl
 

--- a/web/content/partners.md
+++ b/web/content/partners.md
@@ -3,7 +3,7 @@
 Discord Templates is the place for you to discover a huge variety of Discord server templates for
 all purposes.
 
-- Image: https://discordtemplates.me/icon.png
+- Image: https://github.com/chamburr/modmail/assets/51924672/4356e754-cbb6-4a57-8c68-4bdd08315605
 - Link: https://discordtemplates.me
 
 # CH's amburr
@@ -11,7 +11,7 @@ all purposes.
 CH's amburr is the developer's personal community server. It is a fun and friendly place where you
 can talk about everything cool.
 
-- Image: https://cdn.discordapp.com/icons/447732123340767232/5a1064a156540e36e22a38abc527c737.png
+- Image: https://github.com/chamburr/modmail/assets/51924672/a2c397b7-b081-4c2a-a2d1-70ec964344ff
 - Link: https://discord.gg/TYe3U4w
 
 # Member Count
@@ -19,5 +19,5 @@ can talk about everything cool.
 A bot that counts members, users, bots, roles, channels, and other statistics with voice channel
 names ― server stats.
 
-- Image: https://membercount.net/img/logo256.png
+- Image: https://github.com/chamburr/modmail/assets/51924672/d5ece71d-eb75-436a-8cdb-12457269a454
 - Link: https://membercount.net

--- a/web/pages/about.vue
+++ b/web/pages/about.vue
@@ -13,7 +13,7 @@
           <div class="pb-4">
             <img
               class="about-icon mw-100 mh-100 rounded-circle"
-              :src="`${element.image}`"
+              :src="element.image"
               alt="Icon"
             />
           </div>

--- a/web/pages/about.vue
+++ b/web/pages/about.vue
@@ -13,7 +13,7 @@
           <div class="pb-4">
             <img
               class="about-icon mw-100 mh-100 rounded-circle"
-              :src="`${element.image}?size=512`"
+              :src="`${element.image}`"
               alt="Icon"
             />
           </div>

--- a/web/pages/partners.vue
+++ b/web/pages/partners.vue
@@ -15,7 +15,7 @@
             <div class="col-12 col-lg-4 pb-4 px-3 pb-lg-0">
               <img
                 class="partner-icon mw-100 mh-100 rounded-circle"
-                :src="`${element.image}?size=512`"
+                :src="`${element.image}`"
                 alt="Icon"
               />
             </div>

--- a/web/pages/partners.vue
+++ b/web/pages/partners.vue
@@ -15,7 +15,7 @@
             <div class="col-12 col-lg-4 pb-4 px-3 pb-lg-0">
               <img
                 class="partner-icon mw-100 mh-100 rounded-circle"
-                :src="`${element.image}`"
+                :src="element.image"
                 alt="Icon"
               />
             </div>


### PR DESCRIPTION
**Wait a couple of hours to merge this** - I'm only like 80% sure the ibb.co links will stay active, but it's free hosting. This should alleviate some problems with people changing their Discord pictures. Discord will also start removing photos from their CDN after a period of time, so best to migrate photos sooner.

If this doesn't work, then I'll rewrite the page to skip using the about.md information and put the photos in the static/ folder

This version of the link will stay forever: https://ibb.co/dpbsvWb
but the direct url to the .png file could change. It is not clear on the site
