### PR TITLE
chore(hosting): Add anonymous user enviroment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,7 @@ DEFAULT_SERVER=
 BOT_CLUSTERS=
 
 DEFAULT_ANON_USER_NAME=Anonymous#0000
-DEFAULT_ANON_USER_ICON=
+DEFAULT_ANON_USER_ICON=https://cdn.discordapp.com/embed/avatars/0.png
 
 ##################### Users ######################
 

--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,9 @@ DEFAULT_SERVER=
 # Number of clusters
 BOT_CLUSTERS=
 
+DEFAULT_ANON_USER_NAME=Anonymous#0000
+DEFAULT_ANON_USER_ICON=
+
 ##################### Users ######################
 
 # Main support server

--- a/cogs/core.py
+++ b/cogs/core.py
@@ -58,10 +58,10 @@ class Core(commands.Cog):
             timestamp=True,
         )
         embed.set_author(
-            str(ctx.author) if anon is False else "Anonymous#0000",
+            str(ctx.author) if anon is False else self.bot.config.DEFAULT_ANON_USER_NAME,
             ctx.author.avatar_url
             if anon is False
-            else "https://cdn.discordapp.com/embed/avatars/0.png",
+            else self.bot.config.DEFAULT_ANON_USER_ICON,
         )
         embed.set_footer(f"{ctx.guild.name} | {ctx.guild.id}", ctx.guild.icon_url)
 

--- a/cogs/modmail_channel.py
+++ b/cogs/modmail_channel.py
@@ -72,10 +72,10 @@ class ModMailEvents(commands.Cog):
 
         embed = Embed("Message Received", message.content, colour=0xFF4500, timestamp=True)
         embed.set_author(
-            str(message.author) if anon is False else "Anonymous#0000",
+            str(message.author) if anon is False else self.bot.config.DEFAULT_ANON_USER_NAME,
             message.author.avatar_url
             if anon is False
-            else "https://cdn.discordapp.com/embed/avatars/0.png",
+            else self.bot.config.DEFAULT_ANON_USER_ICON,
         )
         embed.set_footer(f"{message.guild.name} | {message.guild.id}", message.guild.icon_url)
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -13,6 +13,9 @@ DEFAULT_PREFIX==
 # Default server to send messages to
 DEFAULT_SERVER=
 
+DEFAULT_ANON_USER_NAME=Anonymous#0000
+DEFAULT_ANON_USER_ICON=https://cdn.discordapp.com/embed/avatars/0.png
+
 ##################### Users ######################
 
 # Bot owner and admin users


### PR DESCRIPTION
**Summary**
Adds environment variables for the `Anonymous#0000` user name and icon to be overridden in the `.env` file.

**Related issue(s)**
[Suggestion #572 on the support server.](https://canary.discord.com/channels/576016832956334080/576765354051633178/1193278010284064901)

**Additional context**
This seemed like such a simple misc change that I decided to make a PR for it.
This will be most useful for self hosts and will mean they don't need to directly edit the codebase to customise this.
