### PR TITLE
fix(core): Changes whitelist/blacklist command check from MemberConverter to UserConverter

### DIFF
--- a/cogs/core.py
+++ b/cogs/core.py
@@ -5,7 +5,7 @@ import logging
 
 import discord
 
-from discord.ext import commands
+from discord.ext import commands, user
 
 from classes.embed import Embed, ErrorEmbed
 from utils import checks, tools
@@ -271,7 +271,7 @@ class Core(commands.Cog):
         usage="whitelist <member>",
         aliases=["unblock"],
     )
-    async def whitelist(self, ctx, *, member: MemberConverter):
+    async def whitelist(self, ctx, *, member: user):
         blacklist = (await tools.get_data(self.bot, ctx.guild.id))[9]
 
         if member.id not in blacklist:

--- a/cogs/core.py
+++ b/cogs/core.py
@@ -9,7 +9,7 @@ from discord.ext import commands
 
 from classes.embed import Embed, ErrorEmbed
 from utils import checks, tools
-from utils.converters import MemberConverter, UserConverter
+from utils.converters import UserConverter
 
 log = logging.getLogger(__name__)
 
@@ -245,19 +245,19 @@ class Core(commands.Cog):
     @commands.guild_only()
     @commands.command(
         description="Blacklist a user to prevent them from creating tickets.",
-        usage="blacklist <member>",
+        usage="blacklist <user>",
         aliases=["block"],
     )
-    async def blacklist(self, ctx, *, member: UserConverter):
+    async def blacklist(self, ctx, *, user: UserConverter):
         blacklist = (await tools.get_data(self.bot, ctx.guild.id))[9]
-        if member.id in blacklist:
+        if user.id in blacklist:
             await ctx.send(ErrorEmbed("The user is already blacklisted."))
             return
 
         async with self.bot.pool.acquire() as conn:
             await conn.execute(
                 "UPDATE data SET blacklist=array_append(blacklist, $1) WHERE guild=$2",
-                member.id,
+                user.id,
                 ctx.guild.id,
             )
 
@@ -268,20 +268,20 @@ class Core(commands.Cog):
     @commands.guild_only()
     @commands.command(
         description="Whitelist a user to allow them to create tickets.",
-        usage="whitelist <member>",
+        usage="whitelist <user>",
         aliases=["unblock"],
     )
-    async def whitelist(self, ctx, *, member: UserConverter):
+    async def whitelist(self, ctx, *, user: UserConverter):
         blacklist = (await tools.get_data(self.bot, ctx.guild.id))[9]
 
-        if member.id not in blacklist:
+        if user.id not in blacklist:
             await ctx.send(ErrorEmbed("The user is not blacklisted."))
             return
 
         async with self.bot.pool.acquire() as conn:
             await conn.execute(
                 "UPDATE data SET blacklist=array_remove(blacklist, $1) WHERE guild=$2",
-                member.id,
+                user.id,
                 ctx.guild.id,
             )
 

--- a/cogs/core.py
+++ b/cogs/core.py
@@ -5,11 +5,11 @@ import logging
 
 import discord
 
-from discord.ext import commands, user
+from discord.ext import commands
 
 from classes.embed import Embed, ErrorEmbed
 from utils import checks, tools
-from utils.converters import MemberConverter
+from utils.converters import MemberConverter, UserConverter
 
 log = logging.getLogger(__name__)
 
@@ -248,7 +248,7 @@ class Core(commands.Cog):
         usage="blacklist <member>",
         aliases=["block"],
     )
-    async def blacklist(self, ctx, *, member: MemberConverter):
+    async def blacklist(self, ctx, *, member: UserConverter):
         blacklist = (await tools.get_data(self.bot, ctx.guild.id))[9]
         if member.id in blacklist:
             await ctx.send(ErrorEmbed("The user is already blacklisted."))
@@ -271,7 +271,7 @@ class Core(commands.Cog):
         usage="whitelist <member>",
         aliases=["unblock"],
     )
-    async def whitelist(self, ctx, *, member: user):
+    async def whitelist(self, ctx, *, member: UserConverter):
         blacklist = (await tools.get_data(self.bot, ctx.guild.id))[9]
 
         if member.id not in blacklist:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: ..
       dockerfile: docker/web/Dockerfile
     image: chamburr/modmail-web:latest
-    container_name: ${Bot_Name}-web
+    container_name: web
     restart: unless-stopped
     ports:
       - '8000:6000'
@@ -24,7 +24,7 @@ services:
       context: ..
       dockerfile: docker/api/Dockerfile
     image: chamburr/modmail-api:latest
-    container_name: ${Bot_Name}-api
+    container_name: api
     restart: unless-stopped
     environment:
       - BOT_TOKEN=${BOT_TOKEN}
@@ -55,7 +55,7 @@ services:
       context: ..
       dockerfile: docker/bot/Dockerfile
     image: chamburr/modmail-bot:latest
-    container_name: ${Bot_Name}-bot
+    container_name: bot
     restart: unless-stopped
     environment:
       - ENVIRONMENT=development
@@ -98,7 +98,7 @@ services:
 
   dispatch:
     image: chamburr/twilight-dispatch:latest
-    container_name: ${Bot_Name}-dispatch
+    container_name: dispatch
     restart: unless-stopped
     environment:
       - RUST_LOG=info
@@ -141,7 +141,7 @@ services:
 
   postgres:
     image: postgres:15-alpine
-    container_name: ${Bot_Name}-postgres
+    container_name: postgres
     restart: unless-stopped
     environment:
       - POSTGRES_DB=modmail
@@ -151,12 +151,12 @@ services:
 
   redis:
     image: redis:7-alpine
-    container_name: ${Bot_Name}-redis
+    container_name: redis
     restart: unless-stopped
 
   rabbitmq:
     image: rabbitmq:3-alpine
-    container_name: ${Bot_Name}-rabitmq
+    container_name: rabitmq
     restart: unless-stopped
 
 volumes:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       context: ..
       dockerfile: docker/web/Dockerfile
     image: chamburr/modmail-web:latest
+    container_name: ${Bot_Name}-web
     restart: unless-stopped
     ports:
       - '8000:6000'
@@ -23,6 +24,7 @@ services:
       context: ..
       dockerfile: docker/api/Dockerfile
     image: chamburr/modmail-api:latest
+    container_name: ${Bot_Name}-api
     restart: unless-stopped
     environment:
       - BOT_TOKEN=${BOT_TOKEN}
@@ -53,6 +55,7 @@ services:
       context: ..
       dockerfile: docker/bot/Dockerfile
     image: chamburr/modmail-bot:latest
+    container_name: ${Bot_Name}-bot
     restart: unless-stopped
     environment:
       - ENVIRONMENT=development
@@ -95,6 +98,7 @@ services:
 
   dispatch:
     image: chamburr/twilight-dispatch:latest
+    container_name: ${Bot_Name}-dispatch
     restart: unless-stopped
     environment:
       - RUST_LOG=info
@@ -137,6 +141,7 @@ services:
 
   postgres:
     image: postgres:15-alpine
+    container_name: ${Bot_Name}-postgres
     restart: unless-stopped
     environment:
       - POSTGRES_DB=modmail
@@ -146,10 +151,12 @@ services:
 
   redis:
     image: redis:7-alpine
+    container_name: ${Bot_Name}-redis
     restart: unless-stopped
 
   rabbitmq:
     image: rabbitmq:3-alpine
+    container_name: ${Bot_Name}-rabitmq
     restart: unless-stopped
 
 volumes:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: ..
       dockerfile: docker/web/Dockerfile
-    image: chamburr/modmail-web:lates
+    image: chamburr/modmail-web:latest
     restart: unless-stopped
     ports:
       - '8000:6000'

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,8 +5,7 @@ services:
     build:
       context: ..
       dockerfile: docker/web/Dockerfile
-    image: chamburr/modmail-web:latest
-    container_name: web
+    image: chamburr/modmail-web:lates
     restart: unless-stopped
     ports:
       - '8000:6000'
@@ -24,7 +23,6 @@ services:
       context: ..
       dockerfile: docker/api/Dockerfile
     image: chamburr/modmail-api:latest
-    container_name: api
     restart: unless-stopped
     environment:
       - BOT_TOKEN=${BOT_TOKEN}
@@ -55,7 +53,6 @@ services:
       context: ..
       dockerfile: docker/bot/Dockerfile
     image: chamburr/modmail-bot:latest
-    container_name: bot
     restart: unless-stopped
     environment:
       - ENVIRONMENT=development
@@ -98,7 +95,6 @@ services:
 
   dispatch:
     image: chamburr/twilight-dispatch:latest
-    container_name: dispatch
     restart: unless-stopped
     environment:
       - RUST_LOG=info
@@ -141,7 +137,6 @@ services:
 
   postgres:
     image: postgres:15-alpine
-    container_name: postgres
     restart: unless-stopped
     environment:
       - POSTGRES_DB=modmail
@@ -151,12 +146,10 @@ services:
 
   redis:
     image: redis:7-alpine
-    container_name: redis
     restart: unless-stopped
 
   rabbitmq:
     image: rabbitmq:3-alpine
-    container_name: rabitmq
     restart: unless-stopped
 
 volumes:

--- a/web/content/commands.md
+++ b/web/content/commands.md
@@ -123,14 +123,14 @@ Close all of the channels anonymously.
 
 Blacklist a user to prevent them from creating tickets.
 
-- Usage: `<member>`
+- Usage: `<user>`
 - Alias: block
 
 ## whitelist
 
 Whitelist a user to allow them to creating tickets.
 
-- Usage: `<member>`
+- Usage: `<user>`
 - Alias: unblock
 
 ## blacklistclear


### PR DESCRIPTION
**Summary**
Changed the whitelist command to do a check against `discord.user` instead of the custom `MemberConverter`. This is because if a member is not in the server then the bot can not resolve them to have them removed from the blacklist.

This could be superseded by a `USerConverter` or a check in the `MemberConveter to check if the user is fectable.

**Related issue(s)**
#160 

**Additional context**
Add any other context or screenshots about the pull request here.
