### PR TITLE
fix: using @Modmail for prefix is not ignored

### DIFF
--- a/cogs/modmail_channel.py
+++ b/cogs/modmail_channel.py
@@ -24,9 +24,9 @@ class ModMailEvents(commands.Cog):
         if permissions.send_messages is False or permissions.embed_links is False:
             return
 
-        prefix = await tools.get_guild_prefix(self.bot, message.guild)
-        for prefixes in [f"<@{self.bot.id}> ", f"<@!{self.bot.id}> ", prefix]:
-            if message.content.startswith(prefixes):
+        guild_prefix = await tools.get_guild_prefix(self.bot, message.guild)
+        for prefix in [f"<@{self.bot.id}> ", f"<@!{self.bot.id}> ", guild_prefix]:
+            if message.content.startswith(prefix):
                 return
 
         data = await tools.get_data(self.bot, message.guild.id)

--- a/cogs/modmail_channel.py
+++ b/cogs/modmail_channel.py
@@ -25,8 +25,9 @@ class ModMailEvents(commands.Cog):
             return
 
         prefix = await tools.get_guild_prefix(self.bot, message.guild)
-        if message.content.startswith(prefix):
-            return
+        for prefixes in [f"<@{self.bot.id}> ", f"<@!{self.bot.id}> ", prefix]:
+            if message.content.startswith(prefixes):
+                return
 
         data = await tools.get_data(self.bot, message.guild.id)
         if data[11] is True:


### PR DESCRIPTION
When in a modmail channel, if you use a Modmail command with pinging the bot (`@Modmail close`) then that message will be sent to the person who opened the ticket, as well as running the command.