### PR TITLE
feat(bot): Add argument explanation to help footer

### DIFF
--- a/cogs/general.py
+++ b/cogs/general.py
@@ -45,6 +45,11 @@ class General(commands.Cog):
             elif len(command.aliases) > 0:
                 embed.add_field("Alias", f"`{command.aliases[0]}`")
 
+            embed.set_footer(
+                "Arguments wrapped in <> are required, ones in [] are optional\n"
+                "Don't include <> or [] in the command, it won't work as expected."
+            )
+
             await ctx.send(embed)
             return
 

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -47,7 +47,8 @@ class General(commands.Cog):
 
             embed.set_footer(
                 "Arguments wrapped in <> are required, ones in [] are optional\n"
-                "Don't include <> or [] in the command, it won't work as expected."
+                "Don't include <> or [] in the command, otherwise, the command won't "
+                "work as expected."
             )
 
             await ctx.send(embed)

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -46,9 +46,9 @@ class General(commands.Cog):
                 embed.add_field("Alias", f"`{command.aliases[0]}`")
 
             embed.set_footer(
-                "Arguments wrapped in <> are required, ones in [] are optional\n"
-                "Don't include <> or [] in the command, otherwise, the command won't "
-                "work as expected."
+                "<> ~ Required Arguments\n"
+                "[] ~ Optional Arguments\n"
+                "Do not include <> or [] when using the command"
             )
 
             await ctx.send(embed)


### PR DESCRIPTION
**Summary**
Adds an explanation to the footer of the help command response, explaining `[]` and `<>` around arguments, to prevent confusion, as including the brackets is a common mistake.

**Related issue(s)**
#167 

**Additional context**
Before
![image](https://github.com/chamburr/modmail/assets/97131358/76a303ad-d3d6-4358-9a71-87ac563c2e6f)


After
![image](https://github.com/chamburr/modmail/assets/97131358/84be6a59-9ecc-40e6-8381-c6d9d24fc318)
