### PR TITLE
feat(bot): vs alias for viewsnippet

### DIFF
--- a/cogs/snippet.py
+++ b/cogs/snippet.py
@@ -127,7 +127,7 @@ class Snippet(commands.Cog):
     @commands.guild_only()
     @commands.command(
         description="View all the snippets or a specific one if specified.",
-        aliases=["viewsnippets", "snippetlist"],
+        aliases=["viewsnippets", "snippetlist", "vs"],
         usage="viewsnippet [name]",
     )
     async def viewsnippet(self, ctx, *, name: str = None):


### PR DESCRIPTION
**Summary**
Adds `vs` as an alias for `=viewsnippet`

**Related issue(s)**
[Suggestion #607](https://discord.com/channels/576016832956334080/576765354051633178/1212576666757369876) in the discord.

**Additional context**
N/A
