### PR TITLE
Add exclude muted members option

### DIFF
--- a/cogs/configuration.py
+++ b/cogs/configuration.py
@@ -91,6 +91,31 @@ class Configuration(commands.Cog):
 
     @commands.guild_only()
     @commands.command(
+        description="Prohibit muted members from creating a ticket",
+        usage="excludemuted",
+    )
+    async def excludemuted(self, ctx):
+        if (await ctx.message.member.guild_permissions()).administrator is False:
+            raise commands.MissingPermissions(["administrator"])
+            
+        data = await tools.get_data(self.bot, ctx.guild.id)
+        toset = True
+        if data[15] is True:
+            toset = False
+        
+        async with self.bot.pool.acquire() as conn:
+            await conn.execute("UPDATE data SET excludemuted=$1 WHERE guild=$2", toset, ctx.guild.id)
+        
+        await ctx.send(
+            Embed(
+                "Block timed out members is now "
+                f"`{'Enabled' if toset is True else 'Disabled'}`.",
+            )
+        )
+
+    
+    @commands.guild_only()
+    @commands.command(
         description="Change the prefix or view the current prefix.",
         usage="prefix [new prefix]",
         aliases=["setprefix"],

--- a/cogs/direct_message.py
+++ b/cogs/direct_message.py
@@ -52,6 +52,16 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
             )
             return
 
+        if data[15] is True:
+            embed = ErrorEmbed(
+                "Ticket Not Created",
+                "You can't create a ticket because you are timed out.",
+                timestamp=True,
+            )
+            embed.set_footer(f"{guild.name} | {guild.id}", guild.icon_url)
+            await message.channel.send(embed)
+            return
+
         channel = None
         for text_channel in await guild.text_channels():
             if tools.is_modmail_channel(text_channel, message.author.id):
@@ -63,16 +73,6 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
                 embed = ErrorEmbed(
                     "Ticket Creation Disabled",
                     data[12] if data[12] else "No reason was provided.",
-                    timestamp=True,
-                )
-                embed.set_footer(f"{guild.name} | {guild.id}", guild.icon_url)
-                await message.channel.send(embed)
-                return
-
-            if data[14] is True:
-                embed = ErrorEmbed(
-                    "Ticket Not Created",
-                    "You can't create a ticket because you are timed out.",
                     timestamp=True,
                 )
                 embed.set_footer(f"{guild.name} | {guild.id}", guild.icon_url)

--- a/cogs/direct_message.py
+++ b/cogs/direct_message.py
@@ -69,6 +69,16 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
                 await message.channel.send(embed)
                 return
 
+            if data[14] is True:
+                embed = ErrorEmbed(
+                    "Ticket Not Created",
+                    "You can't create a ticket because you are timed out.",
+                    timestamp=True,
+                )
+                embed.set_footer(f"{guild.name} | {guild.id}", guild.icon_url)
+                await message.channel.send(embed)
+                return
+
             self.bot.prom.tickets.inc({})
 
             name = "".join(

--- a/cogs/direct_message.py
+++ b/cogs/direct_message.py
@@ -52,7 +52,7 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
             )
             return
 
-        if data[15] is True:
+        if data[15] is True and message.author.communication_disabled_until is not None:
             embed = ErrorEmbed(
                 "Ticket Not Created",
                 "You can't create a ticket because you are timed out.",

--- a/migrations/2022-05-01-135059_initialize_db/up.sql
+++ b/migrations/2022-05-01-135059_initialize_db/up.sql
@@ -12,6 +12,7 @@ CREATE TABLE data
     blacklist   bigint[] NOT NULL,
     anonymous   boolean  NOT NULL,
     commandonly boolean  NOT NULL,
+    excludemuted boolean NOT NULL,
     PRIMARY KEY (guild)
 );
 

--- a/migrations/2024-04-29-192931_add_exclude_muted_members/down.sql
+++ b/migrations/2024-04-29-192931_add_exclude_muted_members/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE data DROP COLUMN excludemuted;

--- a/migrations/2024-04-29-192931_add_exclude_muted_members/up.sql
+++ b/migrations/2024-04-29-192931_add_exclude_muted_members/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE data ADD COLUMN excludemuted boolean;

--- a/utils/tools.py
+++ b/utils/tools.py
@@ -181,7 +181,7 @@ async def get_data(bot, guild):
             return res
 
         return await conn.fetchrow(
-            "INSERT INTO data VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) "
+            "INSERT INTO data VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14) "
             "RETURNING *",
             guild,
             None,
@@ -196,6 +196,7 @@ async def get_data(bot, guild):
             False,
             False,
             None,
+            False,
         )
 
 


### PR DESCRIPTION
**Summary**
This feature will allow moderators/admins/owners to exclude currently timed out members from creating tickets. This issue came up in my server recently where people kept creating tickets even though they were muted, and for no reason but to troll. Making this "exclude muted members" will allow us to prohibit timed out members from creating tickets.