### PR TITLE
fix(web): Fix logs and status updates

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -22,4 +22,4 @@ ADMIN_USERS=
 ##################### Server #####################
 
 # Web server
-BASE_URI=http://localhost:3000
+BASE_URI=http://localhost:8000

--- a/web/nuxt.config.js
+++ b/web/nuxt.config.js
@@ -107,15 +107,10 @@ export default {
 
   axios: {
     baseURL: '/api',
+    browserBaseURL: `${process.env.BASE_URI}/api`,
     credentials: true,
     headers: {
       'Cache-Control': 'max-age=0',
-    },
-  },
-
-  publicRuntimeConfig: {
-    axios: {
-      baseURL: `${process.env.BASE_URI}/api`,
     },
   },
 

--- a/web/nuxt.config.js
+++ b/web/nuxt.config.js
@@ -106,7 +106,7 @@ export default {
   },
 
   axios: {
-    baseURL: '/api',
+    baseURL: `http://${process.env.HTTP_HOST}:${process.env.HTTP_PORT}/api`,
     browserBaseURL: `${process.env.BASE_URI}/api`,
     credentials: true,
     headers: {


### PR DESCRIPTION
Requests from the server will be directed to localhost:6000 instead of localhost:8000
Affects `/logs/<id>` and `/status` pages



