### PR TITLE
feat(bot): Get guild ID from links in incoming message content

### DIFF
--- a/cogs/direct_message.py
+++ b/cogs/direct_message.py
@@ -345,15 +345,19 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
         if self.bot.config.DEFAULT_SERVER is not None:
             guild = await self.bot.get_guild(int(self.bot.config.DEFAULT_SERVER))
         else:
-            async for msg in message.channel.history(limit=30):
-                if (
-                    msg.author.id == self.bot.id
-                    and len(msg.embeds) > 0
-                    and msg.embeds[0].title in ["Message Received", "Message Sent"]
-                ):
-                    guild = msg.embeds[0].footer.text.split()[-1]
-                    guild = await self.bot.get_guild(int(guild))
-                    break
+            guild_id = tools.get_guild_id_from_content_links(message.content)
+            if guild_id is None:
+                async for msg in message.channel.history(limit=30):
+                    if (
+                        msg.author.id == self.bot.id
+                        and len(msg.embeds) > 0
+                        and msg.embeds[0].title in ["Message Received", "Message Sent"]
+                    ):
+                        guild_id = int(msg.embeds[0].footer.text.split()[-1])
+                        break
+
+            if guild_id:
+                guild = await self.bot.get_guild(guild_id)
 
             settings = await tools.get_user_settings(self.bot, message.author.id)
             if settings is None or settings[0] is True:

--- a/utils/tools.py
+++ b/utils/tools.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import time
 
 import discord
@@ -371,3 +372,8 @@ def tag_format(message, author):
         return message[:2045] + "..."
 
     return message
+
+
+def get_guild_id_from_content_links(content):
+    urls = re.findall(r"https:\/\/discord\.com\/channels\/(\d+)", content)
+    return int(urls[0]) if urls else None


### PR DESCRIPTION
**Summary**
When the bot receives a message, it will scan the content for a URL that links to a Discord message. If such an URL is found, it will extract the Guild ID from the URL and use it as the suggested option.

This will allow users to avoid going through the Guild picker if they copy a message link when they report a message.

**Related issue(s)**
[Suggestion 649](https://discord.com/channels/576016832956334080/576765354051633178/1324663584453820457)
