### PR TITLE
feat: migrate to discord.py 2.7.1

### DIFF
--- a/classes/bot.py
+++ b/classes/bot.py
@@ -151,24 +151,16 @@ class ModMail(commands.AutoShardedBot):
             int(x): Session(y) for x, y in (await self._connection.get("gateway_sessions")).items()
         }
 
-    async def get_channel(
-        self, channel_id: int | None
-    ) -> Any:
+    async def get_channel(self, channel_id: int | None) -> Any:
         return await self._connection.get_channel(channel_id)
 
-    async def get_guild(
-        self, guild_id: int | None
-    ) -> Guild | None:
+    async def get_guild(self, guild_id: int | None) -> Guild | None:
         return await self._connection._get_guild(guild_id)
 
-    async def get_user(
-        self, user_id: int
-    ) -> discord.User | None:
+    async def get_user(self, user_id: int) -> discord.User | None:
         return await self._connection.get_user(user_id)
 
-    async def get_emoji(
-        self, emoji_id: int | None
-    ) -> discord.Emoji | None:
+    async def get_emoji(self, emoji_id: int | None) -> discord.Emoji | None:
         return await self._connection.get_emoji(emoji_id)
 
     async def get_all_channels(
@@ -274,9 +266,7 @@ class ModMail(commands.AutoShardedBot):
         if self._amqp is not None:
             await self._amqp.close()
 
-    async def start(
-        self, worker: bool = True
-    ) -> None:
+    async def start(self, worker: bool = True) -> None:
         loop = asyncio.get_running_loop()
         self.loop = loop
         self.http.loop = loop

--- a/classes/bot.py
+++ b/classes/bot.py
@@ -1,18 +1,21 @@
+from __future__ import annotations
+
 import asyncio
+import datetime
 import logging
 import re
-import sys
 import traceback
+
+from typing import TYPE_CHECKING, Any
 
 import aio_pika
 import aiohttp
 import aioredis
 import asyncpg
-import orjson
 import discord
+import orjson
 
 from discord.ext import commands
-from discord.ext.commands.core import _CaseInsensitiveDict
 from discord.gateway import DiscordClientWebSocketResponse, DiscordWebSocket
 from groq import AsyncGroq
 
@@ -23,11 +26,17 @@ from utils import tools
 from utils.config import Config
 from utils.prometheus import Prometheus
 
+if TYPE_CHECKING:
+    from classes.guild import Guild
+    from classes.message import Message
+
 log = logging.getLogger(__name__)
 
 
 class ModMail(commands.AutoShardedBot):
-    def __init__(self, command_prefix=None, **kwargs):
+    _connection: State
+
+    def __init__(self, command_prefix: Any = None, **kwargs: Any) -> None:
         intents = discord.Intents.default()
         intents.message_content = True
         intents.members = True
@@ -36,7 +45,8 @@ class ModMail(commands.AutoShardedBot):
             command_prefix=command_prefix,
             intents=intents,
             case_insensitive=True,
-            **kwargs
+            help_command=None,
+            **kwargs,
         )
 
         self.ws = None
@@ -49,25 +59,26 @@ class ModMail(commands.AutoShardedBot):
         self._closed = False
         self._ready = asyncio.Event()
 
-        self._redis = None
-        self._amqp = None
-        self._amqp_channel = None
-        self._amqp_queue = None
+        self._redis: aioredis.Redis | None = None
+        self._amqp: aio_pika.abc.AbstractRobustConnection | None = None
+        self._amqp_channel: aio_pika.abc.AbstractRobustChannel | None = None
+        self._amqp_queue: aio_pika.abc.AbstractRobustQueue | None = None
 
         self.config = Config()
-        self.session = aiohttp.ClientSession(loop=self.loop)
+        self.session: aiohttp.ClientSession = discord.utils.MISSING
         self.http_uri = f"http://{self.config.BOT_API_HOST}:{self.config.BOT_API_PORT}"
-        self.id = kwargs.get("bot_id")
-        self.cluster = kwargs.get("cluster_id")
-        self.cluster_count = kwargs.get("cluster_count")
-        self.version = kwargs.get("version")
-        self.pool = None
-        self.prom = None
-        self.ai = None
+        self.id: int | None = kwargs.get("bot_id")
+        self.cluster: int | None = kwargs.get("cluster_id")
+        self.cluster_count: int | None = kwargs.get("cluster_count")
+        self.version: str | None = kwargs.get("version")
+        self.pool: asyncpg.Pool = discord.utils.MISSING
+        self.prom: Prometheus = discord.utils.MISSING
+        self.ai: AsyncGroq | None = None
 
         self._enabled_events = [
             "MESSAGE_CREATE",
             "MESSAGE_REACTION_ADD",
+            "INTERACTION_CREATE",
             "READY",
         ]
 
@@ -87,67 +98,90 @@ class ModMail(commands.AutoShardedBot):
         ]
 
     @property
-    def state(self):
+    def state(self) -> State:
         return self._connection
 
     @property
-    def user(self):
+    def user(self) -> discord.User:
         return tools.create_fake_user(self.id)
 
-    async def real_user(self):
+    async def real_user(self) -> discord.ClientUser | None:
         return await self._connection.user()
 
-    async def users(self):
+    async def users(
+        self,
+    ) -> list[discord.User]:
         return await self._connection._users()
 
-    async def guilds(self):
+    async def guilds(self) -> list[Guild]:
         return await self._connection.guilds()
 
-    async def emojis(self):
+    async def emojis(
+        self,
+    ) -> list[discord.Emoji]:
         return await self._connection.emojis()
 
-    async def cached_messages(self):
+    async def cached_messages(
+        self,
+    ) -> list[Message]:
         return await self._connection._messages()
 
-    async def private_channels(self):
+    async def private_channels(
+        self,
+    ) -> list[Any]:
         return await self._connection.private_channels()
 
-    async def shard_count(self):
+    async def shard_count(self) -> int:
         return int(await self._connection.get("gateway_shards"))
 
-    async def started(self):
+    async def started(self) -> datetime.datetime | None:
         started_at = await self._connection.get("gateway_started")
         if started_at:
-            return discord.utils.parse_time(str(started_at).split(".")[0])
+            started = discord.utils.parse_time(str(started_at).split(".")[0])
+            if started.tzinfo is None:
+                started = started.replace(tzinfo=datetime.timezone.utc)
+            return started
         return None
 
-    async def statuses(self):
+    async def statuses(self) -> list[Status]:
         return [Status(x) for x in await self._connection.get("gateway_statuses")]
 
-    async def sessions(self):
+    async def sessions(self) -> dict[int, Session]:
         return {
             int(x): Session(y) for x, y in (await self._connection.get("gateway_sessions")).items()
         }
 
-    async def get_channel(self, channel_id):
+    async def get_channel(
+        self, channel_id: int | None
+    ) -> Any:
         return await self._connection.get_channel(channel_id)
 
-    async def get_guild(self, guild_id):
+    async def get_guild(
+        self, guild_id: int | None
+    ) -> Guild | None:
         return await self._connection._get_guild(guild_id)
 
-    async def get_user(self, user_id):
+    async def get_user(
+        self, user_id: int
+    ) -> discord.User | None:
         return await self._connection.get_user(user_id)
 
-    async def get_emoji(self, emoji_id):
+    async def get_emoji(
+        self, emoji_id: int | None
+    ) -> discord.Emoji | None:
         return await self._connection.get_emoji(emoji_id)
 
-    async def get_all_channels(self):
+    async def get_all_channels(
+        self,
+    ) -> None:
         pass
 
-    async def get_all_members(self):
+    async def get_all_members(
+        self,
+    ) -> None:
         pass
 
-    async def receive_message(self, msg):
+    async def receive_message(self, msg: bytes) -> None:
         self.ws._dispatch("socket_raw_receive", msg)
         msg = orjson.loads(msg)
         self.ws._dispatch("socket_response", msg)
@@ -179,17 +213,21 @@ class ModMail(commands.AutoShardedBot):
             except asyncio.CancelledError:
                 pass
 
-    async def send_message(self, msg):
+    async def send_message(self, msg: Any) -> None:
         data = orjson.dumps(msg)
         self.ws._dispatch("socket_raw_send", data)
         await self._amqp_channel.default_exchange.publish(
             aio_pika.Message(body=data), routing_key="gateway.send"
         )
 
-    async def on_http_request_start(self, _session, trace_config_ctx, _params):
+    async def on_http_request_start(
+        self, _session: aiohttp.ClientSession, trace_config_ctx: Any, _params: Any
+    ) -> None:
         trace_config_ctx.start = asyncio.get_event_loop().time()
 
-    async def on_http_request_end(self, _session, trace_config_ctx, params):
+    async def on_http_request_end(
+        self, _session: aiohttp.ClientSession, trace_config_ctx: Any, params: Any
+    ) -> None:
         elapsed = asyncio.get_event_loop().time() - trace_config_ctx.start
 
         if elapsed > 1:
@@ -211,26 +249,45 @@ class ModMail(commands.AutoShardedBot):
             }
         )
 
-    async def ai_generate(self, text):
+    async def ai_generate(self, text: str) -> str | None:
         completion = await self.ai.chat.completions.create(
             messages=[{"role": "user", "content": text}],
             model=self.config.GROQ_MODEL,
         )
         return completion.choices[0].message.content
 
-    async def setup_hook(self):
-        self.prom = Prometheus(self)
-        await self.prom.start()
+    async def close(self) -> None:
+        if self._closed:
+            return
 
-        if self.config.GROQ_KEY is not None:
-            self.ai = AsyncGroq(api_key=self.config.GROQ_KEY)
+        self._closed = True
 
-    async def start(self, worker=True):
+        await self.http.close()
+
+        if self.session and not self.session.closed:
+            await self.session.close()
+
+        if self._redis is not None:
+            self._redis.close()
+            await self._redis.wait_closed()
+
+        if self._amqp is not None:
+            await self._amqp.close()
+
+    async def start(
+        self, worker: bool = True
+    ) -> None:
+        loop = asyncio.get_running_loop()
+        self.loop = loop
+        self.http.loop = loop
+
         trace_config = aiohttp.TraceConfig()
         trace_config.on_request_start.append(self.on_http_request_start)
         trace_config.on_request_end.append(self.on_http_request_end)
 
         self.http.connector = aiohttp.TCPConnector()
+        self.http._global_over = asyncio.Event()
+        self.http._global_over.set()
         self.http._HTTPClient__session = aiohttp.ClientSession(
             connector=self.http.connector,
             ws_response_class=DiscordClientWebSocketResponse,
@@ -280,13 +337,13 @@ class ModMail(commands.AutoShardedBot):
             handlers=self._handlers,
             hooks=self._hooks,
             http=self.http,
-            loop=asyncio.get_event_loop(),
+            loop=self.loop,
             redis=self._redis,
             shard_count=int(shard_count_val) if shard_count_val else 1,
         )
         self._connection._get_client = lambda: self
 
-        self.ws = DiscordWebSocket(socket=None, loop=asyncio.get_event_loop())
+        self.ws = DiscordWebSocket(socket=None, loop=self.loop)
         self.ws.token = self.config.BOT_TOKEN
         self.ws._connection = self._connection
         self.ws._discord_parsers = self._connection.parsers
@@ -299,7 +356,16 @@ class ModMail(commands.AutoShardedBot):
             try:
                 await self.load_extension("cogs." + extension)
             except Exception:
-                log.error(f"Failed to load extension {extension}.", file=sys.stderr)
+                log.error(f"Failed to load extension {extension}.")
+                log.error(traceback.format_exc())
+
+        if self.cluster == 1:
+            try:
+                payload = tools.build_slash_commands(self)
+                await self.http.bulk_upsert_global_commands(int(self.config.BOT_CLIENT_ID), payload)
+                log.info(f"Registered {len(payload)} slash commands.")
+            except Exception:
+                log.error("Failed to register slash commands.")
                 log.error(traceback.format_exc())
 
         async with self._amqp_queue.iterator() as queue_iter:

--- a/classes/bot.py
+++ b/classes/bot.py
@@ -9,11 +9,11 @@ import aiohttp
 import aioredis
 import asyncpg
 import orjson
+import discord
 
 from discord.ext import commands
 from discord.ext.commands.core import _CaseInsensitiveDict
 from discord.gateway import DiscordClientWebSocketResponse, DiscordWebSocket
-from discord.utils import parse_time
 from groq import AsyncGroq
 
 from classes.http import HTTPClient
@@ -28,26 +28,19 @@ log = logging.getLogger(__name__)
 
 class ModMail(commands.AutoShardedBot):
     def __init__(self, command_prefix=None, **kwargs):
-        self.command_prefix = command_prefix
-        self.extra_events = {}
-        self._BotBase__cogs = {}
-        self._BotBase__extensions = {}
-        self._checks = []
-        self._check_once = []
-        self._before_invoke = None
-        self._after_invoke = None
-        self._help_command = None
-        self.description = ""
-        self.owner_id = None
-        self.owner_ids = set()
-        self._skip_check = lambda x, y: x == y
-        self.case_insensitive = True
-        self.all_commands = _CaseInsensitiveDict() if self.case_insensitive else {}
-        self.strip_after_prefix = False
+        intents = discord.Intents.default()
+        intents.message_content = True
+        intents.members = True
+
+        super().__init__(
+            command_prefix=command_prefix,
+            intents=intents,
+            case_insensitive=True,
+            **kwargs
+        )
 
         self.ws = None
-        self.loop = asyncio.get_event_loop()
-        self.http = HTTPClient(None, loop=self.loop)
+        self.http = HTTPClient(None)
 
         self._handlers = {"ready": self._handle_ready}
         self._hooks = {}
@@ -123,7 +116,10 @@ class ModMail(commands.AutoShardedBot):
         return int(await self._connection.get("gateway_shards"))
 
     async def started(self):
-        return parse_time(str(await self._connection.get("gateway_started")).split(".")[0])
+        started_at = await self._connection.get("gateway_started")
+        if started_at:
+            return discord.utils.parse_time(str(started_at).split(".")[0])
+        return None
 
     async def statuses(self):
         return [Status(x) for x in await self._connection.get("gateway_statuses")]
@@ -222,16 +218,26 @@ class ModMail(commands.AutoShardedBot):
         )
         return completion.choices[0].message.content
 
+    async def setup_hook(self):
+        self.prom = Prometheus(self)
+        await self.prom.start()
+
+        if self.config.GROQ_KEY is not None:
+            self.ai = AsyncGroq(api_key=self.config.GROQ_KEY)
+
     async def start(self, worker=True):
         trace_config = aiohttp.TraceConfig()
         trace_config.on_request_start.append(self.on_http_request_start)
         trace_config.on_request_end.append(self.on_http_request_end)
+
+        self.http.connector = aiohttp.TCPConnector()
         self.http._HTTPClient__session = aiohttp.ClientSession(
             connector=self.http.connector,
             ws_response_class=DiscordClientWebSocketResponse,
             trace_configs=[trace_config],
         )
-        self.http._token(self.config.BOT_TOKEN, bot=True)
+        self.http.token = self.config.BOT_TOKEN
+        self.session = self.http._HTTPClient__session
 
         self.pool = await asyncpg.create_pool(
             database=self.config.POSTGRES_DATABASE,
@@ -267,34 +273,34 @@ class ModMail(commands.AutoShardedBot):
         if self.config.GROQ_KEY is not None:
             self.ai = AsyncGroq(api_key=self.config.GROQ_KEY)
 
+        shard_count_val = await self._redis.get("gateway_shards")
         self._connection = State(
             id=self.id,
             dispatch=self.dispatch,
             handlers=self._handlers,
             hooks=self._hooks,
             http=self.http,
-            loop=self.loop,
+            loop=asyncio.get_event_loop(),
             redis=self._redis,
-            shard_count=int(await self._redis.get("gateway_shards")),
+            shard_count=int(shard_count_val) if shard_count_val else 1,
         )
         self._connection._get_client = lambda: self
 
-        self.ws = DiscordWebSocket(socket=None, loop=self.loop)
-        self.ws.token = self.http.token
+        self.ws = DiscordWebSocket(socket=None, loop=asyncio.get_event_loop())
+        self.ws.token = self.config.BOT_TOKEN
         self.ws._connection = self._connection
         self.ws._discord_parsers = self._connection.parsers
         self.ws._dispatch = self.dispatch
-        self.ws.call_hooks = self._connection.call_hooks
 
         if not worker:
             return
 
         for extension in self._cogs:
             try:
-                self.load_extension("cogs." + extension)
+                await self.load_extension("cogs." + extension)
             except Exception:
                 log.error(f"Failed to load extension {extension}.", file=sys.stderr)
-                log.error(traceback.print_exc())
+                log.error(traceback.format_exc())
 
         async with self._amqp_queue.iterator() as queue_iter:
             async for message in queue_iter:

--- a/classes/channel.py
+++ b/classes/channel.py
@@ -1,4 +1,10 @@
+from __future__ import annotations
+
 import logging
+
+from typing import TYPE_CHECKING, Any
+
+import discord
 
 from discord import channel, utils
 from discord.channel import CategoryChannel, GroupChannel, StageChannel, VoiceChannel
@@ -8,17 +14,24 @@ from discord.permissions import Permissions
 from classes.embed import Embed
 from classes.invite import Invite
 
+if TYPE_CHECKING:
+    from classes.guild import Guild
+    from classes.member import Member
+    from classes.state import State
+
 log = logging.getLogger(__name__)
 
 
 class TextChannel(channel.TextChannel):
-    def __init__(self, *, state, guild, data):
+    def __init__(self, *, state: State, guild: Guild, data: dict[str, Any]) -> None:
         self._state = state
         self.id = int(data["id"])
         self._type = data.get("type", 0)
         self._update(guild, data)
 
-    def _update(self, guild, data):
+    def _update(
+        self, guild: Guild, data: dict[str, Any]
+    ) -> None:
         self.guild = guild
         self.name = data.get("name", "")
         self.category_id = utils._get_as_snowflake(data, "parent_id")
@@ -30,11 +43,11 @@ class TextChannel(channel.TextChannel):
         self.last_message_id = utils._get_as_snowflake(data, "last_message_id")
         self._fill_overwrites(data)
 
-    async def create_invite(self, *, reason=None, **fields):
+    async def create_invite(self, *, reason: str | None = None, **fields: Any) -> Invite:
         data = await self._state.http.create_invite(self.id, reason=reason, **fields)
         return await Invite.from_incomplete(data=data, state=self._state)
 
-    async def _permissions_for(self, member):
+    async def _permissions_for(self, member: Member) -> Permissions:
         if self.guild.owner_id == member.id:
             return Permissions.all()
 
@@ -80,7 +93,9 @@ class TextChannel(channel.TextChannel):
 
         return base
 
-    async def permissions_for(self, member):
+    async def permissions_for(
+        self, member: Member
+    ) -> Permissions:
         base = await self._permissions_for(member)
 
         denied = Permissions.voice()
@@ -88,26 +103,26 @@ class TextChannel(channel.TextChannel):
 
         return base
 
-    async def send(self, content=None, **kwargs):
+    async def send(self, content: Any = None, **kwargs: Any) -> discord.Message:
         if isinstance(content, Embed):
             return await super().send(embed=content, **kwargs)
         return await super().send(content, **kwargs)
 
 
 class DMChannel(channel.DMChannel):
-    def __init__(self, *, me, state, data):
+    def __init__(self, *, me: Any, state: State, data: dict[str, Any]) -> None:
         self._state = state
-        self.recipient = None
+        self.recipients = []
         self.me = me
         self.id = int(data["id"])
 
-    async def send(self, content=None, **kwargs):
+    async def send(self, content: Any = None, **kwargs: Any) -> discord.Message:
         if isinstance(content, Embed):
             return await super().send(embed=content, **kwargs)
         return await super().send(content, **kwargs)
 
 
-def _channel_factory(channel_type):
+def _channel_factory(channel_type: int) -> tuple[type[Any], ChannelType]:
     value = try_enum(ChannelType, channel_type)
     if value is ChannelType.text:
         return TextChannel, value

--- a/classes/channel.py
+++ b/classes/channel.py
@@ -1,7 +1,7 @@
 import logging
 
 from discord import channel, utils
-from discord.channel import CategoryChannel, GroupChannel, StageChannel, StoreChannel, VoiceChannel
+from discord.channel import CategoryChannel, GroupChannel, StageChannel, VoiceChannel
 from discord.enums import ChannelType, try_enum
 from discord.permissions import Permissions
 
@@ -121,8 +121,6 @@ def _channel_factory(channel_type):
         return GroupChannel, value
     elif value is ChannelType.news:
         return TextChannel, value
-    elif value is ChannelType.store:
-        return StoreChannel, value
     elif value is ChannelType.stage_voice:
         return StageChannel, value
     else:

--- a/classes/channel.py
+++ b/classes/channel.py
@@ -29,9 +29,7 @@ class TextChannel(channel.TextChannel):
         self._type = data.get("type", 0)
         self._update(guild, data)
 
-    def _update(
-        self, guild: Guild, data: dict[str, Any]
-    ) -> None:
+    def _update(self, guild: Guild, data: dict[str, Any]) -> None:
         self.guild = guild
         self.name = data.get("name", "")
         self.category_id = utils._get_as_snowflake(data, "parent_id")
@@ -93,9 +91,7 @@ class TextChannel(channel.TextChannel):
 
         return base
 
-    async def permissions_for(
-        self, member: Member
-    ) -> Permissions:
+    async def permissions_for(self, member: Member) -> Permissions:
         base = await self._permissions_for(member)
 
         denied = Permissions.voice()

--- a/classes/context.py
+++ b/classes/context.py
@@ -1,13 +1,51 @@
+from __future__ import annotations
+
 import logging
 
+from typing import TYPE_CHECKING, Any
+
+import discord
+
 from discord.ext.commands import context
+from discord.http import Route
+
+from classes.message import interaction_body
+
+if TYPE_CHECKING:
+    from classes.bot import ModMail
 
 log = logging.getLogger(__name__)
 
 
-class Context(context.Context):
-    def __init__(self, **kwargs):
+class Context(context.Context["ModMail"]):
+    def __init__(self, **kwargs: Any) -> None:
         super(Context, self).__init__(**kwargs)
 
-    async def send(self, *args, **kwargs):
+    async def send(self, *args: Any, **kwargs: Any) -> discord.Message:
+        interaction = getattr(self.message, "_interaction", None)
+
+        if interaction is not None and "file" not in kwargs and "files" not in kwargs:
+            content = args[0] if args else kwargs.get("content")
+
+            if not interaction.get("responded"):
+                interaction["responded"] = True
+                route = Route(
+                    "PATCH",
+                    "/webhooks/{application_id}/{interaction_token}/messages/@original",
+                    application_id=interaction["application_id"],
+                    interaction_token=interaction["token"],
+                )
+            else:
+                route = Route(
+                    "POST",
+                    "/webhooks/{application_id}/{interaction_token}",
+                    application_id=interaction["application_id"],
+                    interaction_token=interaction["token"],
+                )
+
+            data = await self.bot.http.request(route, json=interaction_body(content, **kwargs))
+            message = self.bot.state.create_message(channel=self.channel, data=data)
+            message._interaction = interaction
+            return message
+
         return await self.channel.send(*args, **kwargs)

--- a/classes/embed.py
+++ b/classes/embed.py
@@ -1,4 +1,6 @@
-import datetime
+from __future__ import annotations
+
+from typing import Any
 
 import discord
 
@@ -6,7 +8,7 @@ from discord import embeds
 
 
 class Embed(embeds.Embed):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         if "colour" not in kwargs:
             kwargs["colour"] = 0x1E90FF
 
@@ -21,21 +23,29 @@ class Embed(embeds.Embed):
 
         super().__init__(**kwargs)
 
-    def set_author(self, name=None, icon_url=None, **kwargs):
+    def set_author(
+        self, name: Any = None, icon_url: Any = None, **kwargs: Any
+    ) -> None:
         super().set_author(name=name, icon_url=icon_url, **kwargs)
 
-    def set_footer(self, text=None, icon_url=None):
+    def set_footer(
+        self, text: Any = None, icon_url: Any = None
+    ) -> None:
         super().set_footer(text=text, icon_url=icon_url)
 
-    def set_thumbnail(self, url=None):
+    def set_thumbnail(
+        self, url: Any = None
+    ) -> None:
         super().set_thumbnail(url=url)
 
-    def add_field(self, name=None, value=None, inline=True):
+    def add_field(
+        self, name: Any = None, value: Any = None, inline: bool = True
+    ) -> None:
         super().add_field(name=name, value=value, inline=inline)
 
 
 class ErrorEmbed(Embed):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         if "colour" not in kwargs:
             kwargs["colour"] = 0xFF0000
 

--- a/classes/embed.py
+++ b/classes/embed.py
@@ -23,24 +23,16 @@ class Embed(embeds.Embed):
 
         super().__init__(**kwargs)
 
-    def set_author(
-        self, name: Any = None, icon_url: Any = None, **kwargs: Any
-    ) -> None:
+    def set_author(self, name: Any = None, icon_url: Any = None, **kwargs: Any) -> None:
         super().set_author(name=name, icon_url=icon_url, **kwargs)
 
-    def set_footer(
-        self, text: Any = None, icon_url: Any = None
-    ) -> None:
+    def set_footer(self, text: Any = None, icon_url: Any = None) -> None:
         super().set_footer(text=text, icon_url=icon_url)
 
-    def set_thumbnail(
-        self, url: Any = None
-    ) -> None:
+    def set_thumbnail(self, url: Any = None) -> None:
         super().set_thumbnail(url=url)
 
-    def add_field(
-        self, name: Any = None, value: Any = None, inline: bool = True
-    ) -> None:
+    def add_field(self, name: Any = None, value: Any = None, inline: bool = True) -> None:
         super().add_field(name=name, value=value, inline=inline)
 
 

--- a/classes/embed.py
+++ b/classes/embed.py
@@ -11,7 +11,7 @@ class Embed(embeds.Embed):
             kwargs["colour"] = 0x1E90FF
 
         if kwargs.get("timestamp", False) is True:
-            kwargs["timestamp"] = datetime.datetime.utcnow()
+            kwargs["timestamp"] = discord.utils.utcnow()
 
         if len(args) == 2:
             kwargs["title"] = args[0]
@@ -21,16 +21,16 @@ class Embed(embeds.Embed):
 
         super().__init__(**kwargs)
 
-    def set_author(self, name=discord.Embed.Empty, icon_url=discord.Embed.Empty, **kwargs):
+    def set_author(self, name=None, icon_url=None, **kwargs):
         super().set_author(name=name, icon_url=icon_url, **kwargs)
 
-    def set_footer(self, text=discord.Embed.Empty, icon_url=discord.Embed.Empty):
+    def set_footer(self, text=None, icon_url=None):
         super().set_footer(text=text, icon_url=icon_url)
 
-    def set_thumbnail(self, url=discord.Embed.Empty):
+    def set_thumbnail(self, url=None):
         super().set_thumbnail(url=url)
 
-    def add_field(self, name=discord.Embed.Empty, value=discord.Embed.Empty, inline=True):
+    def add_field(self, name=None, value=None, inline=True):
         super().add_field(name=name, value=value, inline=inline)
 
 

--- a/classes/guild.py
+++ b/classes/guild.py
@@ -1,15 +1,13 @@
+from __future__ import annotations
+
 import logging
+
+from typing import TYPE_CHECKING, Any
 
 from discord import guild, utils
 from discord.channel import CategoryChannel
 from discord.emoji import Emoji
-from discord.enums import (
-    ChannelType,
-    ContentFilter,
-    NotificationLevel,
-    VerificationLevel,
-    try_enum,
-)
+from discord.enums import ChannelType, ContentFilter, NotificationLevel, VerificationLevel, try_enum
 from discord.member import VoiceState
 from discord.role import Role
 
@@ -17,36 +15,45 @@ from classes.channel import TextChannel, _channel_factory
 from classes.invite import Invite
 from classes.member import Member
 
+if TYPE_CHECKING:
+    from classes.state import State
+
 log = logging.getLogger(__name__)
 
 
 class Guild(guild.Guild):
-    def __init__(self, *, data, state):
+    def __init__(self, *, data: dict[str, Any], state: State) -> None:
         self._state = state
         self._from_data(data)
 
-    def _add_channel(self, channel):
+    def _add_channel(self, channel: Any) -> None:
         return
 
-    def _remove_channel(self, channel):
+    def _remove_channel(self, channel: Any) -> None:
         return
 
-    def _add_member(self, member):
+    def _add_member(self, member: Any) -> None:
         return
 
-    def _remove_member(self, member):
+    def _remove_member(self, member: Any) -> None:
         return
 
-    def _update_voice_state(self, data, channel_id):
+    def _update_voice_state(
+        self, data: dict[str, Any], channel_id: int | None
+    ) -> None:
         return
 
-    def _add_role(self, role):
+    def _add_role(self, role: Any) -> None:
         return
 
-    def _remove_role(self, role_id):
+    def _remove_role(
+        self, role_id: int
+    ) -> None:
         return
 
-    def _from_data(self, guild):
+    def _from_data(
+        self, guild: dict[str, Any]
+    ) -> None:
         member_count = guild.get("member_count", None)
         if member_count is not None:
             self._member_count = member_count
@@ -88,24 +95,43 @@ class Guild(guild.Guild):
         self._afk_channel_id = utils._get_as_snowflake(guild, "afk_channel_id")
 
     async def create_text_channel(
-        self, name, *, overwrites=None, category=None, reason=None, **options
-    ):
+        self,
+        name: str,
+        *,
+        overwrites: Any = None,
+        category: CategoryChannel | None = None,
+        reason: str | None = None,
+        **options: Any,
+    ) -> TextChannel:
         data = await self._create_channel(
-            name, overwrites, ChannelType.text, category, reason=reason, **options
+            name,
+            ChannelType.text,
+            overwrites=overwrites or {},
+            category=category,
+            reason=reason,
+            **options,
         )
         return TextChannel(state=self._state, guild=self, data=data)
 
-    async def create_category(self, name, *, overwrites=None, reason=None, position=None):
+    async def create_category(
+        self,
+        name: str,
+        *,
+        overwrites: Any = None,
+        reason: str | None = None,
+        position: int | None = None,
+    ) -> CategoryChannel:
+        options = {} if position is None else {"position": position}
         data = await self._create_channel(
-            name, overwrites, ChannelType.category, reason=reason, position=position
+            name, ChannelType.category, overwrites=overwrites or {}, reason=reason, **options
         )
         return CategoryChannel(state=self._state, guild=self, data=data)
 
-    async def fetch_member(self, member_id):
+    async def fetch_member(self, member_id: int) -> Member:
         data = await self._state.http.get_member(self.id, member_id)
         return Member(data=data, state=self._state, guild=self)
 
-    async def _channels(self):
+    async def _channels(self) -> list[Any]:
         channels = []
         for channel in await self._state._members_get_all("guild", key_id=self.id, name="channel"):
             factory, _ = _channel_factory(channel["type"])
@@ -113,19 +139,19 @@ class Guild(guild.Guild):
 
         return channels
 
-    async def _emojis(self):
+    async def _emojis(self) -> list[Emoji]:
         return [
             Emoji(guild=self, state=self._state, data=x)
             for x in await self._state._members_get_all("guild", key_id=self.id, name="emoji")
         ]
 
-    async def _members(self):
+    async def _members(self) -> list[Member]:
         return [
             Member(guild=self, state=self._state, data=x)
             for x in await self._state._members_get_all("guild", key_id=self.id, name="member")
         ]
 
-    async def _roles(self):
+    async def _roles(self) -> list[Role]:
         return sorted(
             [
                 Role(guild=self, state=self._state, data=x)
@@ -133,7 +159,9 @@ class Guild(guild.Guild):
             ]
         )
 
-    async def _voice_states(self):
+    async def _voice_states(
+        self,
+    ) -> list[VoiceState]:
         voices = []
         for voice in await self._state._members_get_all("guild", key_id=self.id, name="voice"):
             if voice["channel_id"]:
@@ -144,7 +172,9 @@ class Guild(guild.Guild):
                 voices.append(VoiceState(channel=None, data=voice))
         return voices
 
-    async def _voice_state_for(self, user_id):
+    async def _voice_state_for(
+        self, user_id: int
+    ) -> VoiceState | None:
         state = await self._state.get(f"voice:{self.id}:{user_id}")
         if state and state["channel_id"]:
             channel = await self.get_channel(int(state["channel_id"]))
@@ -154,15 +184,19 @@ class Guild(guild.Guild):
             return VoiceState(channel=None, data=state)
         return None
 
-    async def channels(self):
+    async def channels(self) -> list[Any]:
         return await self._channels()
 
-    async def text_channels(self):
+    async def text_channels(
+        self,
+    ) -> list[TextChannel]:
         channels = [x for x in await self._channels() if isinstance(x, TextChannel)]
         channels.sort(key=lambda x: (x.position, x.id))
         return channels
 
-    async def get_channel(self, channel_id):
+    async def get_channel(
+        self, channel_id: int
+    ) -> Any:
         channel = await self._state.get(f"channel:{channel_id}")
 
         if not channel:
@@ -171,29 +205,33 @@ class Guild(guild.Guild):
         factory, _ = _channel_factory(channel["type"])
         return factory(guild=self, state=self._state, data=channel)
 
-    async def afk_channel(self):
+    async def afk_channel(self) -> Any:
         channel_id = self._afk_channel_id
         return channel_id and await self.get_channel(channel_id)
 
-    async def system_channel(self):
+    async def system_channel(self) -> Any:
         channel_id = self._system_channel_id
         return channel_id and await self.get_channel(channel_id)
 
-    async def rules_channel(self):
+    async def rules_channel(self) -> Any:
         channel_id = self._rules_channel_id
         return channel_id and await self.get_channel(channel_id)
 
-    async def public_updates_channel(self):
+    async def public_updates_channel(
+        self,
+    ) -> Any:
         channel_id = self._public_updates_channel_id
         return channel_id and await self.get_channel(channel_id)
 
-    async def emojis(self):
+    async def emojis(self) -> list[Emoji]:
         return await self._emojis()
 
-    async def members(self):
+    async def members(self) -> list[Member]:
         return await self._members()
 
-    async def get_member(self, user_id):
+    async def get_member(
+        self, user_id: int
+    ) -> Member | None:
         member = await self._state.get(f"member:{self.id}:{user_id}")
 
         if member:
@@ -201,7 +239,7 @@ class Guild(guild.Guild):
 
         return None
 
-    async def me(self):
+    async def me(self) -> Member:
         member = await self.get_member(self._state.id)
 
         if member:
@@ -209,10 +247,12 @@ class Guild(guild.Guild):
 
         return await self.fetch_member(self._state.id)
 
-    async def roles(self):
+    async def roles(self) -> list[Role]:
         return await self._roles()
 
-    async def get_role(self, role_id):
+    async def get_role(
+        self, role_id: int
+    ) -> Role | None:
         role = await self._state.get(f"role:{self.id}:{role_id}")
 
         if role:
@@ -220,10 +260,12 @@ class Guild(guild.Guild):
 
         return None
 
-    async def default_role(self):
+    async def default_role(
+        self,
+    ) -> Role | None:
         return await self.get_role(self.id)
 
-    async def invites(self):
+    async def invites(self) -> list[Invite]:
         data = await self._state.http.invites_from(self.id)
         result = []
         for invite in data:

--- a/classes/guild.py
+++ b/classes/guild.py
@@ -38,22 +38,16 @@ class Guild(guild.Guild):
     def _remove_member(self, member: Any) -> None:
         return
 
-    def _update_voice_state(
-        self, data: dict[str, Any], channel_id: int | None
-    ) -> None:
+    def _update_voice_state(self, data: dict[str, Any], channel_id: int | None) -> None:
         return
 
     def _add_role(self, role: Any) -> None:
         return
 
-    def _remove_role(
-        self, role_id: int
-    ) -> None:
+    def _remove_role(self, role_id: int) -> None:
         return
 
-    def _from_data(
-        self, guild: dict[str, Any]
-    ) -> None:
+    def _from_data(self, guild: dict[str, Any]) -> None:
         member_count = guild.get("member_count", None)
         if member_count is not None:
             self._member_count = member_count
@@ -172,9 +166,7 @@ class Guild(guild.Guild):
                 voices.append(VoiceState(channel=None, data=voice))
         return voices
 
-    async def _voice_state_for(
-        self, user_id: int
-    ) -> VoiceState | None:
+    async def _voice_state_for(self, user_id: int) -> VoiceState | None:
         state = await self._state.get(f"voice:{self.id}:{user_id}")
         if state and state["channel_id"]:
             channel = await self.get_channel(int(state["channel_id"]))
@@ -194,9 +186,7 @@ class Guild(guild.Guild):
         channels.sort(key=lambda x: (x.position, x.id))
         return channels
 
-    async def get_channel(
-        self, channel_id: int
-    ) -> Any:
+    async def get_channel(self, channel_id: int) -> Any:
         channel = await self._state.get(f"channel:{channel_id}")
 
         if not channel:
@@ -229,9 +219,7 @@ class Guild(guild.Guild):
     async def members(self) -> list[Member]:
         return await self._members()
 
-    async def get_member(
-        self, user_id: int
-    ) -> Member | None:
+    async def get_member(self, user_id: int) -> Member | None:
         member = await self._state.get(f"member:{self.id}:{user_id}")
 
         if member:
@@ -250,9 +238,7 @@ class Guild(guild.Guild):
     async def roles(self) -> list[Role]:
         return await self._roles()
 
-    async def get_role(
-        self, role_id: int
-    ) -> Role | None:
+    async def get_role(self, role_id: int) -> Role | None:
         role = await self._state.get(f"role:{self.id}:{role_id}")
 
         if role:

--- a/classes/guild.py
+++ b/classes/guild.py
@@ -8,7 +8,6 @@ from discord.enums import (
     ContentFilter,
     NotificationLevel,
     VerificationLevel,
-    VoiceRegion,
     try_enum,
 )
 from discord.member import VoiceState
@@ -55,7 +54,6 @@ class Guild(guild.Guild):
             self._member_count = 0
 
         self.name = guild.get("name")
-        self.region = try_enum(VoiceRegion, guild.get("region"))
         self.verification_level = try_enum(VerificationLevel, guild.get("verification_level"))
         self.default_notifications = try_enum(
             NotificationLevel, guild.get("default_message_notifications")
@@ -64,13 +62,13 @@ class Guild(guild.Guild):
             ContentFilter, guild.get("explicit_content_filter", 0)
         )
         self.afk_timeout = guild.get("afk_timeout")
-        self.icon = guild.get("icon")
-        self.banner = guild.get("banner")
+        self._icon = guild.get("icon")
+        self._banner = guild.get("banner")
         self.unavailable = guild.get("unavailable", False)
         self.id = int(guild["id"])
         self.mfa_level = guild.get("mfa_level")
         self.features = guild.get("features", [])
-        self.splash = guild.get("splash")
+        self._splash = guild.get("splash")
         self._system_channel_id = utils._get_as_snowflake(guild, "system_channel_id")
         self.description = guild.get("description")
         self.max_presences = guild.get("max_presences")
@@ -80,7 +78,7 @@ class Guild(guild.Guild):
         self.premium_subscription_count = guild.get("premium_subscription_count") or 0
         self._system_channel_flags = guild.get("system_channel_flags", 0)
         self.preferred_locale = guild.get("preferred_locale")
-        self.discovery_splash = guild.get("discovery_splash")
+        self._discovery_splash = guild.get("discovery_splash")
         self._rules_channel_id = utils._get_as_snowflake(guild, "rules_channel_id")
         self._public_updates_channel_id = utils._get_as_snowflake(
             guild, "public_updates_channel_id"

--- a/classes/http.py
+++ b/classes/http.py
@@ -1,13 +1,22 @@
+from __future__ import annotations
+
 import logging
+
+from typing import TYPE_CHECKING, Any
 
 from discord import http
 from discord.http import Route
+
+if TYPE_CHECKING:
+    from discord.http import Response
 
 log = logging.getLogger(__name__)
 
 
 class HTTPClient(http.HTTPClient):
-    def request_guild_members(self, guild_id, query, limit=1):
+    def request_guild_members(
+        self, guild_id: int, query: str, limit: int = 1
+    ) -> Response[list[dict[str, Any]]]:
         return self.request(
             Route(
                 "GET",

--- a/classes/invite.py
+++ b/classes/invite.py
@@ -1,15 +1,24 @@
+from __future__ import annotations
+
 import logging
+
+from typing import TYPE_CHECKING, Any
 
 from discord import invite
 from discord.enums import ChannelType, try_enum
 from discord.invite import PartialInviteChannel, PartialInviteGuild
+
+if TYPE_CHECKING:
+    from classes.state import State
 
 log = logging.getLogger(__name__)
 
 
 class Invite(invite.Invite):
     @classmethod
-    async def from_incomplete(cls, *, state, data):
+    async def from_incomplete(
+        cls, *, state: State, data: dict[str, Any]
+    ) -> Invite:
         try:
             guild = await state._get_guild(int(data["guild"]["id"]))
             if guild is None:

--- a/classes/invite.py
+++ b/classes/invite.py
@@ -16,9 +16,7 @@ log = logging.getLogger(__name__)
 
 class Invite(invite.Invite):
     @classmethod
-    async def from_incomplete(
-        cls, *, state: State, data: dict[str, Any]
-    ) -> Invite:
+    async def from_incomplete(cls, *, state: State, data: dict[str, Any]) -> Invite:
         try:
             guild = await state._get_guild(int(data["guild"]["id"]))
             if guild is None:

--- a/classes/member.py
+++ b/classes/member.py
@@ -1,25 +1,37 @@
+from __future__ import annotations
+
 import logging
 import sys
 
-from discord import Permissions, Status, member, utils
+from typing import TYPE_CHECKING, Any
+
+from discord import Permissions, Role, Status, member, utils
 from discord.activity import create_activity
 from discord.enums import try_enum
+
+if TYPE_CHECKING:
+    from discord.activity import ActivityTypes
+
+    from classes.guild import Guild
+    from classes.state import State
 
 log = logging.getLogger(__name__)
 
 
 class Member(member.Member):
-    def __init__(self, *, data, guild, state):
+    def __init__(self, *, data: dict[str, Any], guild: Guild, state: State) -> None:
         self._state = state
         self._user = state.store_user(data["user"])
         self.guild = guild
         self.joined_at = utils.parse_time(data.get("joined_at"))
         self.premium_since = utils.parse_time(data.get("premium_since"))
-        self._update_roles(data)
+        self._roles = utils.SnowflakeList(map(int, data.get("roles", [])))
         self.nick = data.get("nick", None)
         self._avatar = data.get("user", {}).get("avatar")
 
-    async def guild_permissions(self):
+    async def guild_permissions(
+        self,
+    ) -> Permissions:
         if self.guild.owner_id == self.id:
             return Permissions.all()
 
@@ -32,28 +44,32 @@ class Member(member.Member):
 
         return base
 
-    async def roles(self):
+    async def roles(self) -> list[Role]:
         roles = [x for x in await self.guild.roles() if x.id in self._roles]
         roles.append(await self.guild.default_role())
         roles.sort()
         return roles
 
-    async def _presence(self):
+    async def _presence(self) -> dict[str, Any]:
         return await self._state.get(f"presence:{self.guild.id}:{self._user.id}") or {}
 
-    async def activities(self):
-        return tuple(map(create_activity, (await self._presence()).get("activities", [])))
+    async def activities(
+        self,
+    ) -> tuple[ActivityTypes, ...]:
+        return tuple(
+            create_activity(x, self._state) for x in (await self._presence()).get("activities", [])
+        )
 
-    async def _client_status(self):
+    async def _client_status(self) -> dict[str | None, str]:
         presence = await self._presence()
-        status = {
+        status: dict[str | None, str] = {
             sys.intern(x): sys.intern(y) for x, y in presence.get("client_status", {}).items()
         }
         status[None] = sys.intern(presence["status"]) if presence.get("status") else "offline"
         return status
 
-    async def status(self):
+    async def status(self) -> Status:
         return try_enum(Status, await self._client_status())
 
-    async def is_on_mobile(self):
+    async def is_on_mobile(self) -> bool:
         return "member" in await self._client_status()

--- a/classes/member.py
+++ b/classes/member.py
@@ -17,6 +17,7 @@ class Member(member.Member):
         self.premium_since = utils.parse_time(data.get("premium_since"))
         self._update_roles(data)
         self.nick = data.get("nick", None)
+        self._avatar = data.get("user", {}).get("avatar")
 
     async def guild_permissions(self):
         if self.guild.owner_id == self.id:

--- a/classes/message.py
+++ b/classes/message.py
@@ -86,9 +86,7 @@ class Message(message.Message):
         return self._author
 
     @author.setter
-    def author(
-        self, value: User | Member | None
-    ) -> None:
+    def author(self, value: User | Member | None) -> None:
         self._author = value
 
     @property

--- a/classes/message.py
+++ b/classes/message.py
@@ -1,21 +1,47 @@
+from __future__ import annotations
+
 import copy
 import logging
 
-from discord import message, utils
+from typing import TYPE_CHECKING, Any
+
+from discord import Role, User, message, utils
 from discord.enums import MessageType, try_enum
 from discord.flags import MessageFlags
+from discord.http import Route, handle_message_parameters
 from discord.message import Attachment, MessageReference, flatten_handlers
 from discord.reaction import Reaction
 
 from classes.embed import Embed
 from classes.member import Member
 
+if TYPE_CHECKING:
+    from classes.channel import DMChannel, TextChannel
+    from classes.state import State
+
 log = logging.getLogger(__name__)
+
+
+def interaction_body(content: Any = None, **kwargs: Any) -> dict[str, Any]:
+    body: dict[str, Any] = {}
+
+    embed = kwargs.get("embed")
+    if embed is None and isinstance(content, Embed):
+        embed = content
+        content = None
+
+    if embed is not None:
+        body["embeds"] = [embed.to_dict()]
+
+    if content is not None:
+        body["content"] = str(content)
+
+    return body
 
 
 @flatten_handlers
 class Message(message.Message):
-    def __init__(self, *, state, channel, data):
+    def __init__(self, *, state: State, channel: TextChannel | DMChannel, data: dict[str, Any]):
         self._state = state
         self._data = data
         self.id = int(data["id"])
@@ -25,6 +51,7 @@ class Message(message.Message):
         self.application = data.get("application")
         self.activity = data.get("activity")
         self.channel = channel
+        self.guild = getattr(channel, "guild", None)
         self._edited_timestamp = utils.parse_time(data["edited_timestamp"])
         self.type = try_enum(MessageType, data["type"])
         self.pinned = data["pinned"]
@@ -33,6 +60,7 @@ class Message(message.Message):
         self.tts = data["tts"]
         self.content = data["content"]
         self.nonce = data.get("nonce")
+        self._interaction = data.get("_interaction")
 
         ref = copy.copy(data.get("message_reference"))
         self.reference = MessageReference.with_state(state, ref) if ref is not None else None
@@ -43,12 +71,7 @@ class Message(message.Message):
             self._author = None
 
         try:
-            author = self._author
-            try:
-                author._update_from_message(self._data["member"])
-            except AttributeError:
-                author = Member._from_message(message=self, data=self._data["member"])
-            self._member = author
+            self._member = Member._from_message(message=self, data=self._data["member"])
         except KeyError:
             self._member = None
 
@@ -59,22 +82,26 @@ class Message(message.Message):
                 continue
 
     @property
-    def author(self):
+    def author(self) -> User | Member | None:
         return self._author
 
     @author.setter
-    def author(self, value):
+    def author(
+        self, value: User | Member | None
+    ) -> None:
         self._author = value
 
     @property
-    def member(self):
+    def member(self) -> Member | None:
         return self._member
 
     @member.setter
-    def member(self, value):
+    def member(self, value: Any) -> None:
         return
 
-    async def reactions(self):
+    async def reactions(
+        self,
+    ) -> list[Reaction]:
         reactions = []
 
         for reaction in self._data.get("reactions", []):
@@ -83,10 +110,12 @@ class Message(message.Message):
 
         return reactions
 
-    async def mentions(self):
+    async def mentions(
+        self,
+    ) -> list[User | Member]:
         try:
             mentions = self._data["mentions"]
-            members = []
+            members: list[User | Member] = []
             guild = self.guild
             state = self._state
 
@@ -106,7 +135,9 @@ class Message(message.Message):
         except KeyError:
             return []
 
-    async def role_mentions(self):
+    async def role_mentions(
+        self,
+    ) -> list[Role]:
         try:
             mentions = self._data["mention_roles"]
             roles = []
@@ -122,9 +153,28 @@ class Message(message.Message):
         except KeyError:
             return []
 
-    async def edit(self, content=None, **kwargs):
+    async def edit(self, content: Any = None, **kwargs: Any) -> Message:
+        interaction = getattr(self, "_interaction", None)
+        if interaction is not None:
+            data = await self._state.http.request(
+                Route(
+                    "PATCH",
+                    "/webhooks/{application_id}/{interaction_token}/messages/{message_id}",
+                    application_id=interaction["application_id"],
+                    interaction_token=interaction["token"],
+                    message_id=self.id,
+                ),
+                json=interaction_body(content, **kwargs),
+            )
+            message = self._state.create_message(channel=self.channel, data=data)
+            message._interaction = interaction
+            return message
+
         if isinstance(content, Embed):
-            return await super().edit(embed=content, **kwargs)
+            kwargs["embed"] = content
         elif content is not None:
-            return await super().edit(content=content, **kwargs)
-        return await super().edit(**kwargs)
+            kwargs["content"] = content
+
+        params = handle_message_parameters(**kwargs)
+        data = await self._state.http.edit_message(self.channel.id, self.id, params=params)
+        return self._state.create_message(channel=self.channel, data=data)

--- a/classes/misc.py
+++ b/classes/misc.py
@@ -1,4 +1,9 @@
+from __future__ import annotations
+
+import datetime
 import logging
+
+from typing import Any
 
 from discord.utils import parse_time
 
@@ -6,34 +11,34 @@ log = logging.getLogger(__name__)
 
 
 class Session:
-    def __init__(self, data):
+    def __init__(self, data: dict[str, Any]) -> None:
         self._data = data
 
     @property
-    def session_id(self):
+    def session_id(self) -> str:
         return self._data["session_id"]
 
     @property
-    def sequence(self):
+    def sequence(self) -> int:
         return self._data["sequence"]
 
 
 class Status:
-    def __init__(self, data):
+    def __init__(self, data: dict[str, Any]) -> None:
         self._data = data
 
     @property
-    def shard(self):
+    def shard(self) -> int:
         return self._data["shard"]
 
     @property
-    def status(self):
+    def status(self) -> str:
         return self._data["status"]
 
     @property
-    def latency(self):
+    def latency(self) -> float:
         return self._data["latency"]
 
     @property
-    def last_ack(self):
+    def last_ack(self) -> datetime.datetime:
         return parse_time(self._data["last_ack"].split(".")[0])

--- a/classes/state.py
+++ b/classes/state.py
@@ -164,7 +164,7 @@ class State:
 
     async def _users(self):
         user_ids = set([x.split(":")[2] for x in await self._members("member")])
-        return [User(state=self, data=x["user"]) for x in await self.get(user_ids)]
+        return [User(state=self, data=x["user"]) for x in await self.get(list(user_ids))]
 
     async def _emojis(self):
         results = await self._members_get_all("emoji")
@@ -375,7 +375,7 @@ class State:
 
         self.dispatch("connect")
         self._ready_state = asyncio.Queue()
-        self._ready_task = asyncio.ensure_future(self._delay_ready(), loop=self.loop)
+        self._ready_task = asyncio.ensure_future(self._delay_ready())
 
     async def parse_resumed(self, data, old):
         self.dispatch("resumed")
@@ -519,7 +519,7 @@ class State:
             if user_update:
                 self.dispatch("user_update", user_update[1], user_update[0])
 
-        self.dispatch("member_update", old_member, member)
+        self.dispatch("presence_update", old_member, member)
 
     async def parse_user_update(self, data, old):
         return
@@ -754,7 +754,7 @@ class State:
                     "typing",
                     channel,
                     member,
-                    datetime.datetime.utcfromtimestamp(data.get("timestamp")),
+                    datetime.datetime.fromtimestamp(data.get("timestamp"), tz=datetime.timezone.utc),
                 )
 
     async def parse_relationship_add(self, data, old):

--- a/classes/state.py
+++ b/classes/state.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
 import asyncio
 import copy
 import datetime
 import inspect
 import logging
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 import orjson
 
@@ -29,13 +34,28 @@ from classes.guild import Guild
 from classes.member import Member
 from classes.message import Message
 
+if TYPE_CHECKING:
+    import aioredis
+
+    from classes.http import HTTPClient
+
 log = logging.getLogger(__name__)
 
 
 class State:
     def __init__(
-        self, *, dispatch, handlers, hooks, http, loop, redis=None, shard_count=None, id, **options
-    ):
+        self,
+        *,
+        dispatch: Callable[..., Any],
+        handlers: dict[str, Callable[..., Any]],
+        hooks: dict[str, Callable[..., Any]],
+        http: HTTPClient,
+        loop: asyncio.AbstractEventLoop,
+        redis: aioredis.Redis | None = None,
+        shard_count: int | None = None,
+        id: int | None,
+        **options: Any,
+    ) -> None:
         self.dispatch = dispatch
         self.handlers = handlers
         self.hooks = hooks
@@ -45,8 +65,8 @@ class State:
         self.shard_count = shard_count
         self.id = id
 
-        self._ready_task = None
-        self._ready_state = None
+        self._ready_task: asyncio.Future[Any] | None = None
+        self._ready_state: asyncio.Queue[Any] | None = None
         self._ready_timeout = options.get("guild_ready_timeout", 2.0)
 
         self._voice_clients = {}
@@ -54,12 +74,12 @@ class State:
 
         self.allowed_mentions = options.get("allowed_mentions")
 
-        self.parsers = {}
+        self.parsers: dict[str, Callable[..., Any]] = {}
         for attr, func in inspect.getmembers(self):
             if attr.startswith("parse_"):
                 self.parsers[attr[6:].upper()] = func
 
-    def _loads(self, value, decode):
+    def _loads(self, value: Any, decode: bool) -> Any:
         if value is None:
             return value
 
@@ -71,15 +91,15 @@ class State:
         except orjson.JSONDecodeError:
             return value.decode("utf-8")
 
-    def _dumps(self, value):
+    def _dumps(self, value: Any) -> str | int | float:
         if isinstance(value, (str, int, float)):
             return value
         return orjson.dumps(value).decode("utf-8")
 
-    async def delete(self, key):
+    async def delete(self, key: str) -> Any:
         return await self.redis.delete(key)
 
-    async def get(self, keys, decode=True):
+    async def get(self, keys: str | list[str] | tuple[str, ...], decode: bool = True) -> Any:
         results = []
         if isinstance(keys, (list, tuple)):
             if len(keys) == 0:
@@ -99,31 +119,31 @@ class State:
 
         return results[0]
 
-    async def expire(self, key, time):
+    async def expire(self, key: str, time: int) -> Any:
         return await self.redis.expire(key, time)
 
-    async def set(self, key, value=None):
+    async def set(self, key: str | list[Any] | tuple[Any, ...], value: Any = None) -> Any:
         if isinstance(key, (list, tuple)):
             return await self.redis.mset(*key)
 
         return await self.redis.set(key, self._dumps(value))
 
-    async def sadd(self, key, *value):
+    async def sadd(self, key: str, *value: Any) -> Any:
         return await self.redis.sadd(key, *[self._dumps(x) for x in value])
 
-    async def srem(self, key, *value):
+    async def srem(self, key: str, *value: Any) -> Any:
         return await self.redis.srem(key, *[self._dumps(x) for x in value])
 
-    async def smembers(self, key, decode=True):
+    async def smembers(self, key: str, decode: bool = True) -> list[Any]:
         return [self._loads(x, decode) for x in await self.redis.smembers(key)]
 
-    async def sismember(self, key, value):
+    async def sismember(self, key: str, value: Any) -> Any:
         return await self.redis.sismember(key, self._dumps(value))
 
-    async def scard(self, key):
+    async def scard(self, key: str) -> Any:
         return await self.redis.scard(key)
 
-    async def _members(self, key, key_id=None):
+    async def _members(self, key: str, key_id: int | None = None) -> list[str]:
         key += "_keys"
 
         if key_id:
@@ -132,8 +152,14 @@ class State:
         return [x.decode("utf-8") for x in await self.redis.smembers(key)]
 
     async def _members_get(
-        self, key, key_id=None, name=None, first=None, second=None, predicate=None
-    ):
+        self,
+        key: str,
+        key_id: int | None = None,
+        name: Any = None,
+        first: Any = None,
+        second: Any = None,
+        predicate: Callable[[str], bool] | None = None,
+    ) -> Any:
         for match in await self._members(key, key_id):
             keys = match.split(":")
             if name is None or keys[0] == str(name):
@@ -145,8 +171,14 @@ class State:
         return None
 
     async def _members_get_all(
-        self, key, key_id=None, name=None, first=None, second=None, predicate=None
-    ):
+        self,
+        key: str,
+        key_id: int | None = None,
+        name: Any = None,
+        first: Any = None,
+        second: Any = None,
+        predicate: Callable[[str], bool] | None = None,
+    ) -> Any:
         matches = []
         for match in await self._members(key, key_id):
             keys = match.split(":")
@@ -158,15 +190,15 @@ class State:
 
         return await self.get(matches)
 
-    def _key_first(self, obj):
+    def _key_first(self, obj: dict[str, Any]) -> int:
         keys = obj["_key"].split(":")
         return int(keys[1])
 
-    async def _users(self):
+    async def _users(self) -> list[User]:
         user_ids = set([x.split(":")[2] for x in await self._members("member")])
         return [User(state=self, data=x["user"]) for x in await self.get(list(user_ids))]
 
-    async def _emojis(self):
+    async def _emojis(self) -> list[Emoji]:
         results = await self._members_get_all("emoji")
         emojis = []
 
@@ -178,14 +210,14 @@ class State:
 
         return emojis
 
-    async def _guilds(self):
+    async def _guilds(self) -> list[Guild]:
         guilds = [Guild(state=self, data=x) for x in await self._members_get_all("guild")]
         return [x for x in guilds if not x.unavailable]
 
-    async def _private_channels(self):
+    async def _private_channels(self) -> list[Any]:
         return []
 
-    async def _messages(self):
+    async def _messages(self) -> list[Message]:
         messages = []
         for result in await self._members_get_all("message"):
             channel = await self.get_channel(int(result["channel_id"]))
@@ -196,10 +228,12 @@ class State:
 
         return messages
 
-    def process_chunk_requests(self, guild_id, nonce, members, complete):
+    def process_chunk_requests(
+        self, guild_id: int, nonce: Any, members: Any, complete: Any
+    ) -> None:
         return
 
-    def call_handlers(self, key, *args, **kwargs):
+    def call_handlers(self, key: str, *args: Any, **kwargs: Any) -> None:
         try:
             func = self.handlers[key]
         except KeyError:
@@ -207,7 +241,7 @@ class State:
         else:
             func(*args, **kwargs)
 
-    async def call_hooks(self, key, *args, **kwargs):
+    async def call_hooks(self, key: str, *args: Any, **kwargs: Any) -> None:
         try:
             func = self.hooks[key]
         except KeyError:
@@ -215,39 +249,39 @@ class State:
         else:
             await func(*args, **kwargs)
 
-    async def user(self):
+    async def user(self) -> ClientUser | None:
         result = await self.get("bot_user")
         if result:
             return ClientUser(state=self, data=result)
         return None
 
-    def self_id(self):
+    def self_id(self) -> int | None:
         return self.id
 
     @property
-    def intents(self):
+    def intents(self) -> None:
         return
 
     @property
-    def voice_clients(self):
+    def voice_clients(self) -> None:
         return
 
-    def _get_voice_client(self, guild_id):
+    def _get_voice_client(self, guild_id: int) -> None:
         return
 
-    def _add_voice_client(self, guild_id, voice):
+    def _add_voice_client(self, guild_id: int, voice: Any) -> None:
         return
 
-    def _remove_voice_client(self, guild_id):
+    def _remove_voice_client(self, guild_id: int) -> None:
         return
 
-    def _update_references(self, ws):
+    def _update_references(self, ws: Any) -> None:
         return
 
-    def store_user(self, data):
+    def store_user(self, data: dict[str, Any], *, cache: bool = True) -> User:
         return User(state=self, data=data)
 
-    async def get_user(self, user_id):
+    async def get_user(self, user_id: int) -> User | None:
         result = await self._members_get("member", second=user_id)
 
         if result:
@@ -255,13 +289,13 @@ class State:
 
         return None
 
-    def store_emoji(self, guild, data):
+    def store_emoji(self, guild: Guild, data: dict[str, Any]) -> Emoji:
         return Emoji(guild=guild, state=self, data=data)
 
-    async def guilds(self):
+    async def guilds(self) -> list[Guild]:
         return await self._guilds()
 
-    async def _get_guild(self, guild_id):
+    async def _get_guild(self, guild_id: int | None) -> Guild | None:
         result = await self.get(f"guild:{guild_id}")
 
         if result:
@@ -271,16 +305,16 @@ class State:
 
         return None
 
-    def _add_guild(self, guild):
+    def _add_guild(self, guild: Any) -> None:
         return
 
-    def _remove_guild(self, guild):
+    def _remove_guild(self, guild: Any) -> None:
         return
 
-    async def emojis(self):
+    async def emojis(self) -> list[Emoji]:
         return await self._emojis()
 
-    async def get_emoji(self, emoji_id):
+    async def get_emoji(self, emoji_id: int | None) -> Emoji | None:
         result = await self._members_get("emoji", second=emoji_id)
 
         if result:
@@ -291,29 +325,29 @@ class State:
 
         return None
 
-    async def private_channels(self):
+    async def private_channels(self) -> list[Any]:
         return await self._private_channels()
 
-    async def _get_private_channel(self, channel_id):
+    async def _get_private_channel(self, channel_id: int) -> DMChannel | None:
         result = await self._get_channel(channel_id)
         if result and isinstance(result, DMChannel):
             return result
 
         return None
 
-    async def _get_private_channel_by_user(self, user_id):
+    async def _get_private_channel_by_user(self, user_id: int) -> Any:
         return utils.find(lambda x: x.recipient.id == user_id, await self.private_channels())
 
-    def _add_private_channel(self, channel):
+    def _add_private_channel(self, channel: Any) -> None:
         return
 
-    def add_dm_channel(self, data):
+    def add_dm_channel(self, data: dict[str, Any]) -> DMChannel:
         return DMChannel(me=self.user, state=self, data=data)
 
-    def _remove_private_channel(self, channel):
+    def _remove_private_channel(self, channel: Any) -> None:
         return
 
-    async def _get_message(self, msg_id):
+    async def _get_message(self, msg_id: int | None) -> Any:
         result = await self._members_get("message", second=msg_id)
 
         if result:
@@ -324,26 +358,30 @@ class State:
 
         return result
 
-    def _add_guild_from_data(self, guild):
+    def _add_guild_from_data(self, guild: dict[str, Any]) -> Guild:
         return Guild(state=self, data=guild)
 
-    def _guild_needs_chunking(self, guild):
+    def _guild_needs_chunking(self, guild: Any) -> None:
         return
 
-    async def _get_guild_channel(self, channel_id):
+    async def _get_guild_channel(self, channel_id: int) -> Any:
         result = await self._get_channel(channel_id)
         if result and not isinstance(result, DMChannel):
             return result
 
         return None
 
-    async def chunker(self, guild_id, query="", limit=0, *, nonce=None):
+    async def chunker(
+        self, guild_id: int, query: str = "", limit: int = 0, *, nonce: Any = None
+    ) -> None:
         return
 
-    async def query_members(self, guild, query, limit, user_ids, cache):
+    async def query_members(
+        self, guild: Any, query: Any, limit: Any, user_ids: Any, cache: Any
+    ) -> None:
         return
 
-    async def _delay_ready(self):
+    async def _delay_ready(self) -> None:
         try:
             while True:
                 try:
@@ -369,7 +407,7 @@ class State:
         finally:
             self._ready_task = None
 
-    async def parse_ready(self, data, old):
+    async def parse_ready(self, data: dict[str, Any], old: Any) -> None:
         if self._ready_task is not None:
             self._ready_task.cancel()
 
@@ -377,10 +415,13 @@ class State:
         self._ready_state = asyncio.Queue()
         self._ready_task = asyncio.ensure_future(self._delay_ready())
 
-    async def parse_resumed(self, data, old):
+    async def parse_resumed(self, data: dict[str, Any], old: Any) -> None:
         self.dispatch("resumed")
 
-    async def parse_message_create(self, data, old):
+    async def parse_interaction_create(self, data: dict[str, Any], old: Any) -> None:
+        self.dispatch("interaction_create", data)
+
+    async def parse_message_create(self, data: dict[str, Any], old: Any) -> None:
         channel = await self.get_channel(int(data["channel_id"]))
 
         if not channel and not data.get("guild_id"):
@@ -390,7 +431,7 @@ class State:
             message = self.create_message(channel=channel, data=data)
             self.dispatch("message", message)
 
-    async def parse_message_delete(self, data, old):
+    async def parse_message_delete(self, data: dict[str, Any], old: Any) -> None:
         raw = RawMessageDeleteEvent(data)
 
         if old:
@@ -402,7 +443,7 @@ class State:
 
         self.dispatch("raw_message_delete", raw)
 
-    async def parse_message_delete_bulk(self, data, old):
+    async def parse_message_delete_bulk(self, data: dict[str, Any], old: Any) -> None:
         raw = RawBulkMessageDeleteEvent(data)
 
         if old:
@@ -417,7 +458,7 @@ class State:
 
         self.dispatch("raw_bulk_message_delete", raw)
 
-    async def parse_message_update(self, data, old):
+    async def parse_message_update(self, data: dict[str, Any], old: Any) -> None:
         raw = RawMessageUpdateEvent(data)
 
         if old:
@@ -431,7 +472,7 @@ class State:
 
         self.dispatch("raw_message_edit", raw)
 
-    async def parse_message_reaction_add(self, data, old):
+    async def parse_message_reaction_add(self, data: dict[str, Any], old: Any) -> None:
         emoji = PartialEmoji.with_state(
             self,
             id=utils._get_as_snowflake(data["emoji"], "id"),
@@ -459,7 +500,7 @@ class State:
             if user:
                 self.dispatch("reaction_add", reaction, user)
 
-    async def parse_message_reaction_remove_all(self, data, old):
+    async def parse_message_reaction_remove_all(self, data: dict[str, Any], old: Any) -> None:
         raw = RawReactionClearEvent(data)
         self.dispatch("raw_reaction_clear", raw)
 
@@ -467,7 +508,7 @@ class State:
         if message:
             self.dispatch("reaction_clear", message, None)
 
-    async def parse_message_reaction_remove(self, data, old):
+    async def parse_message_reaction_remove(self, data: dict[str, Any], old: Any) -> None:
         emoji = PartialEmoji.with_state(
             self,
             id=utils._get_as_snowflake(data["emoji"], "id"),
@@ -487,7 +528,7 @@ class State:
             if user:
                 self.dispatch("reaction_remove", reaction, user)
 
-    async def parse_message_reaction_remove_emoji(self, data, old):
+    async def parse_message_reaction_remove_emoji(self, data: dict[str, Any], old: Any) -> None:
         emoji = PartialEmoji.with_state(
             self,
             id=utils._get_as_snowflake(data["emoji"], "id"),
@@ -504,7 +545,7 @@ class State:
             )
             self.dispatch("reaction_clear_emoji", reaction)
 
-    async def parse_presence_update(self, data, old):
+    async def parse_presence_update(self, data: dict[str, Any], old: Any) -> None:
         guild = await self._get_guild(utils._get_as_snowflake(data, "guild_id"))
 
         if not guild:
@@ -521,18 +562,18 @@ class State:
 
         self.dispatch("presence_update", old_member, member)
 
-    async def parse_user_update(self, data, old):
+    async def parse_user_update(self, data: dict[str, Any], old: Any) -> None:
         return
 
-    async def parse_invite_create(self, data, old):
+    async def parse_invite_create(self, data: dict[str, Any], old: Any) -> None:
         invite = Invite.from_gateway(state=self, data=data)
         self.dispatch("invite_create", invite)
 
-    async def parse_invite_delete(self, data, old):
+    async def parse_invite_delete(self, data: dict[str, Any], old: Any) -> None:
         invite = Invite.from_gateway(state=self, data=data)
         self.dispatch("invite_delete", invite)
 
-    async def parse_channel_delete(self, data, old):
+    async def parse_channel_delete(self, data: dict[str, Any], old: Any) -> None:
         if old and old["guild_id"]:
             guild = await self._get_guild(utils._get_as_snowflake(data, "guild_id"))
             if guild:
@@ -543,7 +584,7 @@ class State:
             channel = DMChannel(me=self.user, state=self, data=old)
             self.dispatch("private_channel_delete", channel)
 
-    async def parse_channel_update(self, data, old):
+    async def parse_channel_update(self, data: dict[str, Any], old: Any) -> None:
         channel_type = try_enum(ChannelType, data.get("type"))
         if old and channel_type is ChannelType.private:
             channel = DMChannel(me=self.user, state=self, data=data)
@@ -558,7 +599,7 @@ class State:
                 old_channel = old_factory(guild=guild, state=self, data=old)
                 self.dispatch("guild_channel_update", old_channel, channel)
 
-    async def parse_channel_create(self, data, old):
+    async def parse_channel_create(self, data: dict[str, Any], old: Any) -> None:
         factory, ch_type = _channel_factory(data["type"])
         if ch_type is ChannelType.private:
             channel = DMChannel(me=self.user, data=data, state=self)
@@ -569,7 +610,7 @@ class State:
                 channel = factory(guild=guild, state=self, data=data)
                 self.dispatch("guild_channel_create", channel)
 
-    async def parse_channel_pins_update(self, data, old):
+    async def parse_channel_pins_update(self, data: dict[str, Any], old: Any) -> None:
         channel = await self.get_channel(int(data["channel_id"]))
         last_pin = (
             utils.parse_time(data["last_pin_timestamp"]) if data["last_pin_timestamp"] else None
@@ -582,26 +623,26 @@ class State:
         else:
             self.dispatch("guild_channel_pins_update", channel, last_pin)
 
-    async def parse_channel_recipient_add(self, data, old):
+    async def parse_channel_recipient_add(self, data: dict[str, Any], old: Any) -> None:
         return
 
-    async def parse_channel_recipient_remove(self, data, old):
+    async def parse_channel_recipient_remove(self, data: dict[str, Any], old: Any) -> None:
         return
 
-    async def parse_guild_member_add(self, data, old):
+    async def parse_guild_member_add(self, data: dict[str, Any], old: Any) -> None:
         guild = await self._get_guild(int(data["guild_id"]))
         if guild:
             member = Member(guild=guild, data=data, state=self)
             self.dispatch("member_join", member)
 
-    async def parse_guild_member_remove(self, data, old):
+    async def parse_guild_member_remove(self, data: dict[str, Any], old: Any) -> None:
         if old:
             guild = await self._get_guild(int(data["guild_id"]))
             if guild:
                 member = Member(guild=guild, data=old, state=self)
                 self.dispatch("member_remove", member)
 
-    async def parse_guild_member_update(self, data, old):
+    async def parse_guild_member_update(self, data: dict[str, Any], old: Any) -> None:
         guild = await self._get_guild(int(data["guild_id"]))
         if old and guild:
             member = await guild.get_member(int(data["user"]["id"]))
@@ -615,7 +656,7 @@ class State:
 
                 self.dispatch("member_update", old_member, member)
 
-    async def parse_guild_emojis_update(self, data, old):
+    async def parse_guild_emojis_update(self, data: dict[str, Any], old: Any) -> None:
         guild = await self._get_guild(int(data["guild_id"]))
         if guild:
             before_emojis = None
@@ -625,16 +666,16 @@ class State:
             after_emojis = tuple(map(lambda x: self.store_emoji(guild, x), data["emojis"]))
             self.dispatch("guild_emojis_update", guild, before_emojis, after_emojis)
 
-    def _get_create_guild(self, data):
+    def _get_create_guild(self, data: dict[str, Any]) -> Guild:
         return self._add_guild_from_data(data)
 
-    async def chunk_guild(self, guild, *, wait=True, cache=None):
+    async def chunk_guild(self, guild: Any, *, wait: bool = True, cache: Any = None) -> None:
         return
 
-    async def _chunk_and_dispatch(self, guild, unavailable):
+    async def _chunk_and_dispatch(self, guild: Any, unavailable: Any) -> None:
         return
 
-    async def parse_guild_create(self, data, old):
+    async def parse_guild_create(self, data: dict[str, Any], old: Any) -> None:
         unavailable = data.get("unavailable")
 
         if unavailable is True:
@@ -649,10 +690,10 @@ class State:
             else:
                 self.dispatch("guild_join", guild)
 
-    async def parse_guild_sync(self, data, old):
+    async def parse_guild_sync(self, data: dict[str, Any], old: Any) -> None:
         return
 
-    async def parse_guild_update(self, data, old):
+    async def parse_guild_update(self, data: dict[str, Any], old: Any) -> None:
         guild = await self._get_guild(int(data["id"]))
         if guild:
             old_guild = None
@@ -663,7 +704,7 @@ class State:
 
             self.dispatch("guild_update", old_guild, guild)
 
-    async def parse_guild_delete(self, data, old):
+    async def parse_guild_delete(self, data: dict[str, Any], old: Any) -> None:
         if old:
             old = Guild(state=self, data=old)
             if data.get("unavailable", False):
@@ -672,32 +713,32 @@ class State:
             else:
                 self.dispatch("guild_remove", old)
 
-    async def parse_guild_ban_add(self, data, old):
+    async def parse_guild_ban_add(self, data: dict[str, Any], old: Any) -> None:
         guild = await self._get_guild(int(data["guild_id"]))
         if guild:
             user = self.store_user(data["user"])
             member = await guild.get_member(user.id) or user
             self.dispatch("member_ban", guild, member)
 
-    async def parse_guild_ban_remove(self, data, old):
+    async def parse_guild_ban_remove(self, data: dict[str, Any], old: Any) -> None:
         guild = await self._get_guild(int(data["guild_id"]))
         if guild:
             self.dispatch("member_unban", guild, self.store_user(data["user"]))
 
-    async def parse_guild_role_create(self, data, old):
+    async def parse_guild_role_create(self, data: dict[str, Any], old: Any) -> None:
         guild = await self._get_guild(int(data["guild_id"]))
         if guild:
             role = Role(guild=guild, state=self, data=data["role"])
             self.dispatch("guild_role_create", role)
 
-    async def parse_guild_role_delete(self, data, old):
+    async def parse_guild_role_delete(self, data: dict[str, Any], old: Any) -> None:
         if old:
             guild = await self._get_guild(int(data["guild_id"]))
             if guild:
                 role = Role(guild=guild, state=self, data=old)
                 self.dispatch("guild_role_delete", role)
 
-    async def parse_guild_role_update(self, data, old):
+    async def parse_guild_role_update(self, data: dict[str, Any], old: Any) -> None:
         if old:
             guild = await self._get_guild(int(data["guild_id"]))
             if guild:
@@ -705,20 +746,20 @@ class State:
                 old_role = Role(guild=guild, state=self, data=old)
                 self.dispatch("guild_role_update", old_role, role)
 
-    async def parse_guild_members_chunk(self, data, old):
+    async def parse_guild_members_chunk(self, data: dict[str, Any], old: Any) -> None:
         return
 
-    async def parse_guild_integrations_update(self, data, old):
+    async def parse_guild_integrations_update(self, data: dict[str, Any], old: Any) -> None:
         guild = await self._get_guild(int(data["guild_id"]))
         if guild:
             self.dispatch("guild_integrations_update", guild)
 
-    async def parse_webhooks_update(self, data, old):
+    async def parse_webhooks_update(self, data: dict[str, Any], old: Any) -> None:
         channel = await self._get_guild(int(data["channel_id"]))
         if channel:
             self.dispatch("webhooks_update", channel)
 
-    async def parse_voice_state_update(self, data, old):
+    async def parse_voice_state_update(self, data: dict[str, Any], old: Any) -> None:
         guild = await self._get_guild(utils._get_as_snowflake(data, "guild_id"))
         if guild:
             member = await guild.get_member(int(data["user_id"]))
@@ -734,10 +775,10 @@ class State:
 
                     self.dispatch("voice_state_update", member, before, after)
 
-    def parse_voice_server_update(self, data, old):
+    def parse_voice_server_update(self, data: dict[str, Any], old: Any) -> None:
         return
 
-    async def parse_typing_start(self, data, old):
+    async def parse_typing_start(self, data: dict[str, Any], old: Any) -> None:
         channel = await self._get_guild_channel(int(data["channel_id"]))
         if channel:
             member = None
@@ -754,21 +795,25 @@ class State:
                     "typing",
                     channel,
                     member,
-                    datetime.datetime.fromtimestamp(data.get("timestamp"), tz=datetime.timezone.utc),
+                    datetime.datetime.fromtimestamp(
+                        data.get("timestamp"), tz=datetime.timezone.utc
+                    ),
                 )
 
-    async def parse_relationship_add(self, data, old):
+    async def parse_relationship_add(self, data: dict[str, Any], old: Any) -> None:
         return
 
-    async def parse_relationship_remove(self, data, old):
+    async def parse_relationship_remove(self, data: dict[str, Any], old: Any) -> None:
         return
 
-    async def _get_reaction_user(self, channel, user_id):
+    async def _get_reaction_user(
+        self, channel: TextChannel | DMChannel, user_id: int
+    ) -> Member | User | None:
         if isinstance(channel, TextChannel):
             return await channel.guild.get_member(user_id)
         return await self.get_user(user_id)
 
-    async def get_reaction_emoji(self, data):
+    async def get_reaction_emoji(self, data: dict[str, Any]) -> Emoji | str | None:
         emoji_id = utils._get_as_snowflake(data, "id")
 
         if not emoji_id:
@@ -776,13 +821,13 @@ class State:
 
         return await self.get_emoji(emoji_id)
 
-    async def _upgrade_partial_emoji(self, emoji):
+    async def _upgrade_partial_emoji(self, emoji: PartialEmoji) -> Emoji | str | None:
         if not emoji.id:
             return emoji.name
 
         return await self.get_emoji(emoji.id)
 
-    async def _get_channel(self, channel_id):
+    async def _get_channel(self, channel_id: int) -> Any:
         result = await self.get(f"channel:{channel_id}")
 
         if result:
@@ -797,12 +842,12 @@ class State:
 
         return None
 
-    async def get_channel(self, channel_id):
+    async def get_channel(self, channel_id: int | None) -> Any:
         if not channel_id:
             return None
 
         return await self._get_channel(channel_id)
 
-    def create_message(self, *, channel, data):
+    def create_message(self, *, channel: Any, data: dict[str, Any]) -> Message:
         message = Message(state=self, channel=channel, data=data)
         return message

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -43,7 +43,7 @@ class Admin(commands.Cog):
             page = Embed(title="Shared Servers")
 
             for guild in chunk:
-                if page.description == discord.Embed.Empty:
+                if page.description is None:
                     page.description = guild
                 else:
                     page.description += f"\n{guild}"
@@ -130,5 +130,5 @@ class Admin(commands.Cog):
         await self.bot.session.post(f"{self.bot.http_uri}/restart")
 
 
-def setup(bot):
-    bot.add_cog(Admin(bot))
+async def setup(bot):
+    await bot.add_cog(Admin(bot))

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import logging
-import typing
 
 from datetime import timezone
 
@@ -7,6 +8,8 @@ import discord
 
 from discord.ext import commands
 
+from classes.bot import ModMail
+from classes.context import Context
 from classes.embed import Embed, ErrorEmbed
 from utils import checks, tools
 from utils.converters import ChannelConverter, DateTimeConverter, GuildConverter, UserConverter
@@ -15,7 +18,7 @@ log = logging.getLogger(__name__)
 
 
 class Admin(commands.Cog):
-    def __init__(self, bot):
+    def __init__(self, bot: ModMail) -> None:
         self.bot = bot
 
     @checks.is_admin()
@@ -23,7 +26,7 @@ class Admin(commands.Cog):
         description="Get a list of servers the bot shares with the user.",
         usage="sharedservers <user>",
     )
-    async def sharedservers(self, ctx, *, user: UserConverter):
+    async def sharedservers(self, ctx: Context, *, user: UserConverter) -> None:
         guilds = [
             f"{guild.name} `{guild.id}` ({guild.member_count} members)"
             for guild in [
@@ -57,7 +60,7 @@ class Admin(commands.Cog):
     @commands.command(
         description="Create an invite to the specified server.", usage="createinvite <server ID>"
     )
-    async def createinvite(self, ctx, *, guild: GuildConverter):
+    async def createinvite(self, ctx: Context, *, guild: GuildConverter) -> None:
         try:
             invite = (await guild.invites())[0]
         except (IndexError, discord.Forbidden):
@@ -73,7 +76,9 @@ class Admin(commands.Cog):
     @commands.command(
         description="Give a user temporary premium.", usage="givepremium <user> <expiry>"
     )
-    async def givepremium(self, ctx, user: UserConverter, *, expiry: DateTimeConverter):
+    async def givepremium(
+        self, ctx: Context, user: UserConverter, *, expiry: DateTimeConverter
+    ) -> None:
         premium = await tools.get_premium_slots(self.bot, user.id)
         if premium:
             await ctx.send(ErrorEmbed("That user already has premium."))
@@ -87,7 +92,7 @@ class Admin(commands.Cog):
 
     @checks.is_admin()
     @commands.command(description="Remove a user's premium.", usage="wipepremium <user>")
-    async def wipepremium(self, ctx, *, user: UserConverter):
+    async def wipepremium(self, ctx: Context, *, user: UserConverter) -> None:
         async with self.bot.pool.acquire() as conn:
             res = await conn.fetchrow("SELECT guild FROM premium WHERE identifier=$1", user.id)
             if res:
@@ -103,7 +108,9 @@ class Admin(commands.Cog):
         description="Transfer a user's premium to another user.",
         usage="transferpremium <user> <other>",
     )
-    async def transferpremium(self, ctx, user: UserConverter, *, other: UserConverter):
+    async def transferpremium(
+        self, ctx: Context, user: UserConverter, *, other: UserConverter
+    ) -> None:
         premium = await tools.get_premium_slots(self.bot, other.id)
         if premium:
             await ctx.send(ErrorEmbed("That user already has premium."))
@@ -118,17 +125,17 @@ class Admin(commands.Cog):
 
     @checks.is_admin()
     @commands.command(description="Make me say something.", usage="echo [channel] <message>")
-    async def echo(self, ctx, channel: typing.Optional[ChannelConverter], *, content: str):
+    async def echo(self, ctx: Context, channel: ChannelConverter | None, *, content: str) -> None:
         channel = channel or ctx.channel
         await ctx.message.delete()
         await channel.send(content, allowed_mentions=discord.AllowedMentions(everyone=False))
 
     @checks.is_admin()
     @commands.command(description="Restart all clusters.", usage="restart")
-    async def restart(self, ctx):
+    async def restart(self, ctx: Context) -> None:
         await ctx.send(Embed("Restarting..."))
         await self.bot.session.post(f"{self.bot.http_uri}/restart")
 
 
-async def setup(bot):
+async def setup(bot: ModMail) -> None:
     await bot.add_cog(Admin(bot))

--- a/cogs/configuration.py
+++ b/cogs/configuration.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
+
 import logging
-import typing
+
+from typing import Any
 
 from discord.errors import Forbidden
 from discord.ext import commands
 from discord.permissions import PermissionOverwrite
 from discord.role import Role
 
+from classes.bot import ModMail
+from classes.context import Context
 from classes.embed import Embed, ErrorEmbed
 from utils import checks, tools
 from utils.converters import ChannelConverter, PingRoleConverter, RoleConverter
@@ -14,10 +19,12 @@ log = logging.getLogger(__name__)
 
 
 class Configuration(commands.Cog):
-    def __init__(self, bot):
+    def __init__(self, bot: ModMail) -> None:
         self.bot = bot
 
-    async def _get_overwrites(self, ctx, roles):
+    async def _get_overwrites(
+        self, ctx: Context, roles: list[int]
+    ) -> dict[Any, PermissionOverwrite]:
         overwrites = {await ctx.guild.default_role(): PermissionOverwrite(read_messages=False)}
 
         for role in roles:
@@ -47,7 +54,7 @@ class Configuration(commands.Cog):
     @checks.has_permissions(administrator=True)
     @commands.guild_only()
     @commands.command(description="Set up ModMail.", usage="setup")
-    async def setup(self, ctx):
+    async def setup(self, ctx: Context) -> None:
         msg = await ctx.send(Embed("Setting up..."))
 
         data = await tools.get_data(self.bot, ctx.guild.id)
@@ -95,7 +102,7 @@ class Configuration(commands.Cog):
         usage="prefix [new prefix]",
         aliases=["setprefix"],
     )
-    async def prefix(self, ctx, *, prefix: str = None):
+    async def prefix(self, ctx: Context, *, prefix: str | None = None) -> None:
         if prefix is None:
             await ctx.send(Embed(f"The prefix for this server is `{ctx.prefix}`."))
             return
@@ -130,7 +137,7 @@ class Configuration(commands.Cog):
     @commands.command(
         description="Re-create the category for the ModMail channels.", usage="category [name]"
     )
-    async def category(self, ctx, *, name: str = "ModMail"):
+    async def category(self, ctx: Context, *, name: str = "ModMail") -> None:
         if len(name) > 100:
             await ctx.send(ErrorEmbed("The category name cannot be longer than 100 characters"))
             return
@@ -164,7 +171,13 @@ class Configuration(commands.Cog):
         aliases=["modrole", "supportrole"],
         usage="accessrole [roles]",
     )
-    async def accessrole(self, ctx, roles: commands.Greedy[RoleConverter] = None, *, check=None):
+    async def accessrole(
+        self,
+        ctx: Context,
+        roles: commands.Greedy[RoleConverter] = None,
+        *,
+        check: str | None = None,
+    ) -> None:
         if roles is None:
             roles = []
 
@@ -226,7 +239,11 @@ class Configuration(commands.Cog):
         aliases=["mentionrole"],
         usage="pingrole [roles]",
     )
-    async def pingrole(self, ctx, roles: commands.Greedy[PingRoleConverter] = None):
+    async def pingrole(
+        self,
+        ctx: Context,
+        roles: commands.Greedy[PingRoleConverter] = None,
+    ) -> None:
         if roles is None:
             roles = []
 
@@ -269,7 +286,7 @@ class Configuration(commands.Cog):
         aliases=["logs"],
         usage="logging [channel]",
     )
-    async def logging(self, ctx, channel: typing.Optional[ChannelConverter]):
+    async def logging(self, ctx: Context, channel: ChannelConverter | None) -> None:
         data = await tools.get_data(self.bot, ctx.guild.id)
 
         if data[4] and channel is None:
@@ -307,7 +324,7 @@ class Configuration(commands.Cog):
         aliases=["commandrequired"],
         usage="commandonly",
     )
-    async def commandonly(self, ctx):
+    async def commandonly(self, ctx: Context) -> None:
         data = await tools.get_data(self.bot, ctx.guild.id)
 
         async with self.bot.pool.acquire() as conn:
@@ -331,7 +348,7 @@ class Configuration(commands.Cog):
         aliases=["welcomemessage", "greetmessage"],
         usage="greetingmessage [text]",
     )
-    async def greetingmessage(self, ctx, *, text: str = None):
+    async def greetingmessage(self, ctx: Context, *, text: str | None = None) -> None:
         async with self.bot.pool.acquire() as conn:
             await conn.execute("UPDATE data SET welcome=$1 WHERE guild=$2", text, ctx.guild.id)
 
@@ -347,7 +364,7 @@ class Configuration(commands.Cog):
         aliases=["goodbyemessage", "closemessage"],
         usage="closingmessage [text]",
     )
-    async def closingmessage(self, ctx, *, text: str = None):
+    async def closingmessage(self, ctx: Context, *, text: str | None = None) -> None:
         async with self.bot.pool.acquire() as conn:
             await conn.execute("UPDATE data SET goodbye=$1 WHERE guild=$2", text, ctx.guild.id)
 
@@ -363,7 +380,7 @@ class Configuration(commands.Cog):
         aliases=["advancedlogging", "advancedlogs"],
         usage="loggingplus",
     )
-    async def loggingplus(self, ctx):
+    async def loggingplus(self, ctx: Context) -> None:
         data = await tools.get_data(self.bot, ctx.guild.id)
 
         async with self.bot.pool.acquire() as conn:
@@ -384,7 +401,7 @@ class Configuration(commands.Cog):
     @checks.has_permissions(administrator=True)
     @commands.guild_only()
     @commands.command(description="Toggle default anonymous messages.", usage="anonymous")
-    async def anonymous(self, ctx):
+    async def anonymous(self, ctx: Context) -> None:
         data = await tools.get_data(self.bot, ctx.guild.id)
 
         async with self.bot.pool.acquire() as conn:
@@ -406,7 +423,7 @@ class Configuration(commands.Cog):
         aliases=["enable", "disable"],
         usage="toggle [reason]",
     )
-    async def toggle(self, ctx, *, reason: str = ""):
+    async def toggle(self, ctx: Context, *, reason: str = "") -> None:
         data = await tools.get_data(self.bot, ctx.guild.id)
 
         async with self.bot.pool.acquire() as conn:
@@ -428,7 +445,7 @@ class Configuration(commands.Cog):
         description="Set or clear the additional AI prompt used by the `aireply` command.",
         usage="aiprompt [text]",
     )
-    async def aiprompt(self, ctx, *, text: str = None):
+    async def aiprompt(self, ctx: Context, *, text: str | None = None) -> None:
         async with self.bot.pool.acquire() as conn:
             await conn.execute("UPDATE data SET aiprompt=$1 WHERE guild=$2", text, ctx.guild.id)
 
@@ -440,7 +457,7 @@ class Configuration(commands.Cog):
     @commands.command(
         description="View the configurations for the current server.", usage="viewconfig"
     )
-    async def viewconfig(self, ctx):
+    async def viewconfig(self, ctx: Context) -> None:
         data = await tools.get_data(self.bot, ctx.guild.id)
         category = await ctx.guild.get_channel(data[2])
         logging = await ctx.guild.get_channel(data[4])
@@ -501,5 +518,5 @@ class Configuration(commands.Cog):
         await ctx.send(embed)
 
 
-async def setup(bot):
+async def setup(bot: ModMail) -> None:
     await bot.add_cog(Configuration(bot))

--- a/cogs/configuration.py
+++ b/cogs/configuration.py
@@ -501,5 +501,5 @@ class Configuration(commands.Cog):
         await ctx.send(embed)
 
 
-def setup(bot):
-    bot.add_cog(Configuration(bot))
+async def setup(bot):
+    await bot.add_cog(Configuration(bot))

--- a/cogs/core.py
+++ b/cogs/core.py
@@ -1,13 +1,19 @@
+from __future__ import annotations
+
 import asyncio
 import copy
 import io
 import logging
 import time
 
+from typing import Any
+
 import discord
 
 from discord.ext import commands
 
+from classes.bot import ModMail
+from classes.context import Context
 from classes.embed import Embed, ErrorEmbed
 from utils import checks, tools
 from utils.converters import UserConverter
@@ -16,7 +22,7 @@ log = logging.getLogger(__name__)
 
 
 class Core(commands.Cog):
-    def __init__(self, bot):
+    def __init__(self, bot: ModMail) -> None:
         self.bot = bot
 
     @checks.is_modmail_channel()
@@ -24,7 +30,7 @@ class Core(commands.Cog):
     @checks.is_mod()
     @commands.guild_only()
     @commands.command(description="Reply to the ticket.", usage="reply <message>", aliases=["r"])
-    async def reply(self, ctx, *, message):
+    async def reply(self, ctx: Context, *, message: str) -> None:
         ctx.message.content = message
         await self.bot.cogs["ModMailEvents"].send_mail_mod(ctx.message, ctx.prefix, anon=False)
 
@@ -35,7 +41,7 @@ class Core(commands.Cog):
     @commands.command(
         description="Reply to the ticket anonymously.", usage="areply <message>", aliases=["ar"]
     )
-    async def areply(self, ctx, *, message):
+    async def areply(self, ctx: Context, *, message: str) -> None:
         ctx.message.content = message
         await self.bot.cogs["ModMailEvents"].send_mail_mod(ctx.message, ctx.prefix, anon=True)
 
@@ -50,7 +56,7 @@ class Core(commands.Cog):
         usage="aireply <instructions>",
         aliases=["air"],
     )
-    async def aireply(self, ctx, *, instructions: str = None):
+    async def aireply(self, ctx: Context, *, instructions: str | None = None) -> None:
         if self.bot.ai is None:
             await ctx.send(ErrorEmbed("AI features are disabled."))
             return
@@ -103,7 +109,7 @@ class Core(commands.Cog):
             f"reaction_menu:{msg.channel.id}:{msg.id}",
         )
 
-    async def generate_history(self, channel):
+    async def generate_history(self, channel: Any) -> str:
         history = ""
         messages = [message async for message in channel.history(limit=10000)]
 
@@ -148,7 +154,7 @@ class Core(commands.Cog):
 
         return history
 
-    async def close_channel(self, ctx, reason, anon: bool = False):
+    async def close_channel(self, ctx: Context, reason: str | None, anon: bool = False) -> None:
         await ctx.send(Embed("Closing ticket..."))
 
         data = await tools.get_data(self.bot, ctx.guild.id)
@@ -167,7 +173,9 @@ class Core(commands.Cog):
             reason if reason else "No reason was provided.",
             timestamp=True,
         )
-        embed.set_footer(f"{ctx.guild.name} | {ctx.guild.id}", (ctx.guild.icon.url if ctx.guild.icon else None))
+        embed.set_footer(
+            f"{ctx.guild.name} | {ctx.guild.id}", (ctx.guild.icon.url if ctx.guild.icon else None)
+        )
 
         if anon is False:
             embed.set_author(str(ctx.author.name), ctx.author.display_avatar.url)
@@ -186,7 +194,10 @@ class Core(commands.Cog):
                     colour=0xFF4500,
                     timestamp=True,
                 )
-                embed2.set_footer(f"{ctx.guild.name} | {ctx.guild.id}", (ctx.guild.icon.url if ctx.guild.icon else None))
+                embed2.set_footer(
+                    f"{ctx.guild.name} | {ctx.guild.id}",
+                    (ctx.guild.icon.url if ctx.guild.icon else None),
+                )
                 try:
                     await dm_channel.send(embed2)
                 except discord.Forbidden:
@@ -266,7 +277,7 @@ class Core(commands.Cog):
     @checks.bot_has_permissions(manage_channels=True)
     @commands.guild_only()
     @commands.command(description="Close the ticket.", usage="close [reason]", aliases=["c"])
-    async def close(self, ctx, *, reason: str = None):
+    async def close(self, ctx: Context, *, reason: str | None = None) -> None:
         await self.close_channel(ctx, reason)
 
     @checks.is_modmail_channel()
@@ -277,7 +288,7 @@ class Core(commands.Cog):
     @commands.command(
         description="Close the ticket anonymously.", usage="aclose [reason]", aliases=["ac"]
     )
-    async def aclose(self, ctx, *, reason: str = None):
+    async def aclose(self, ctx: Context, *, reason: str | None = None) -> None:
         await self.close_channel(ctx, reason, True)
 
     @checks.in_database()
@@ -285,7 +296,7 @@ class Core(commands.Cog):
     @checks.bot_has_permissions(manage_channels=True)
     @commands.guild_only()
     @commands.command(description="Close all the tickets.", usage="closeall [reason]")
-    async def closeall(self, ctx, *, reason: str = None):
+    async def closeall(self, ctx: Context, *, reason: str | None = None) -> None:
         for channel in await ctx.guild.text_channels():
             if tools.is_modmail_channel(channel):
                 msg = copy.copy(ctx.message)
@@ -303,7 +314,7 @@ class Core(commands.Cog):
     @checks.bot_has_permissions(manage_channels=True)
     @commands.guild_only()
     @commands.command(description="Close all the tickets anonymously.", usage="acloseall [reason]")
-    async def acloseall(self, ctx, *, reason: str = None):
+    async def acloseall(self, ctx: Context, *, reason: str | None = None) -> None:
         for channel in await ctx.guild.text_channels():
             if tools.is_modmail_channel(channel):
                 msg = copy.copy(ctx.message)
@@ -325,7 +336,13 @@ class Core(commands.Cog):
         usage="blacklist [users]",
         aliases=["block"],
     )
-    async def blacklist(self, ctx, users: commands.Greedy[UserConverter] = None, *, check=None):
+    async def blacklist(
+        self,
+        ctx: Context,
+        users: commands.Greedy[UserConverter] = None,
+        *,
+        check: str | None = None,
+    ) -> None:
         if users is None:
             users = []
             if tools.is_modmail_channel(ctx.channel):
@@ -363,7 +380,13 @@ class Core(commands.Cog):
         usage="whitelist [users]",
         aliases=["unblock"],
     )
-    async def whitelist(self, ctx, users: commands.Greedy[UserConverter] = None, *, check=None):
+    async def whitelist(
+        self,
+        ctx: Context,
+        users: commands.Greedy[UserConverter] = None,
+        *,
+        check: str | None = None,
+    ) -> None:
         if users is None:
             users = []
             if tools.is_modmail_channel(ctx.channel):
@@ -396,7 +419,7 @@ class Core(commands.Cog):
     @checks.is_mod()
     @commands.guild_only()
     @commands.command(description="Remove all users from the blacklist.", usage="blacklistclear")
-    async def blacklistclear(self, ctx):
+    async def blacklistclear(self, ctx: Context) -> None:
         async with self.bot.pool.acquire() as conn:
             await conn.execute("UPDATE data SET blacklist=$1 WHERE guild=$2", [], ctx.guild.id)
 
@@ -406,7 +429,7 @@ class Core(commands.Cog):
     @checks.is_mod()
     @commands.guild_only()
     @commands.command(description="View the blacklist.", usage="viewblacklist")
-    async def viewblacklist(self, ctx):
+    async def viewblacklist(self, ctx: Context) -> None:
         blacklist = (await tools.get_data(self.bot, ctx.guild.id))[9]
         if not blacklist:
             await ctx.send(Embed("No one is blacklisted."))
@@ -427,5 +450,5 @@ class Core(commands.Cog):
         await tools.create_paginator(self.bot, ctx, all_pages)
 
 
-async def setup(bot):
+async def setup(bot: ModMail) -> None:
     await bot.add_cog(Core(bot))

--- a/cogs/core.py
+++ b/cogs/core.py
@@ -105,7 +105,7 @@ class Core(commands.Cog):
 
     async def generate_history(self, channel):
         history = ""
-        messages = await channel.history(limit=10000).flatten()
+        messages = [message async for message in channel.history(limit=10000)]
 
         for message in messages:
             if message.author.bot and (
@@ -167,10 +167,10 @@ class Core(commands.Cog):
             reason if reason else "No reason was provided.",
             timestamp=True,
         )
-        embed.set_footer(f"{ctx.guild.name} | {ctx.guild.id}", ctx.guild.icon_url)
+        embed.set_footer(f"{ctx.guild.name} | {ctx.guild.id}", (ctx.guild.icon.url if ctx.guild.icon else None))
 
         if anon is False:
-            embed.set_author(str(ctx.author.name), ctx.author.avatar_url)
+            embed.set_author(str(ctx.author.name), ctx.author.display_avatar.url)
 
         try:
             member = await ctx.guild.fetch_member(tools.get_modmail_user(ctx.channel).id)
@@ -186,7 +186,7 @@ class Core(commands.Cog):
                     colour=0xFF4500,
                     timestamp=True,
                 )
-                embed2.set_footer(f"{ctx.guild.name} | {ctx.guild.id}", ctx.guild.icon_url)
+                embed2.set_footer(f"{ctx.guild.name} | {ctx.guild.id}", (ctx.guild.icon.url if ctx.guild.icon else None))
                 try:
                     await dm_channel.send(embed2)
                 except discord.Forbidden:
@@ -211,7 +211,7 @@ class Core(commands.Cog):
                 pass
 
         if member:
-            embed.set_footer(f"{member.name} | {member.id}", member.avatar_url)
+            embed.set_footer(f"{member.name} | {member.id}", member.display_avatar.url)
         else:
             embed.set_footer(
                 "Unknown | 000000000000000000",
@@ -220,7 +220,7 @@ class Core(commands.Cog):
 
         embed.set_author(
             str(ctx.author.name) if anon is False else f"{ctx.author.name} (Anonymous)",
-            ctx.author.avatar_url,
+            ctx.author.display_avatar.url,
         )
 
         if data[7] > 0:
@@ -420,12 +420,12 @@ class Core(commands.Cog):
 
         if len(all_pages) == 1:
             embed = all_pages[0]
-            embed.set_footer(discord.Embed.Empty)
+            embed.set_footer(None)
             await ctx.send(embed)
             return
 
         await tools.create_paginator(self.bot, ctx, all_pages)
 
 
-def setup(bot):
-    bot.add_cog(Core(bot))
+async def setup(bot):
+    await bot.add_cog(Core(bot))

--- a/cogs/direct_message.py
+++ b/cogs/direct_message.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import io
 import logging
 import string
@@ -7,7 +9,10 @@ import discord
 
 from discord.ext import commands
 
+from classes.bot import ModMail
+from classes.context import Context
 from classes.embed import Embed, ErrorEmbed
+from classes.guild import Guild
 from classes.message import Message
 from utils import tools
 from utils.converters import GuildConverter
@@ -16,11 +21,11 @@ log = logging.getLogger(__name__)
 
 
 class DirectMessageEvents(commands.Cog, name="Direct Message"):
-    def __init__(self, bot):
+    def __init__(self, bot: ModMail) -> None:
         self.bot = bot
         self.guild = None
 
-    async def send_mail(self, message, guild):
+    async def send_mail(self, message: Message, guild: Guild | None) -> None:
         self.bot.prom.tickets_message.inc({})
 
         if not guild:
@@ -65,7 +70,9 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
                     data[12] if data[12] else "No reason was provided.",
                     timestamp=True,
                 )
-                embed.set_footer(f"{guild.name} | {guild.id}", (guild.icon.url if guild.icon else None))
+                embed.set_footer(
+                    f"{guild.name} | {guild.id}", (guild.icon.url if guild.icon else None)
+                )
                 await message.channel.send(embed)
                 return
 
@@ -191,7 +198,9 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
                     colour=0xFF4500,
                     timestamp=True,
                 )
-                embed.set_footer(f"{guild.name} | {guild.id}", (guild.icon.url if guild.icon else None))
+                embed.set_footer(
+                    f"{guild.name} | {guild.id}", (guild.icon.url if guild.icon else None)
+                )
 
                 await message.channel.send(embed)
 
@@ -229,7 +238,7 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
             )
 
     @commands.Cog.listener()
-    async def on_raw_reaction_add(self, payload):
+    async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent) -> None:
         if payload.user_id == self.bot.id:
             return
 
@@ -323,9 +332,9 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
                         pass
 
     @commands.Cog.listener()
-    async def on_message(self, message):
+    async def on_message(self, message: Message) -> None:
         if (
-            message.is_system
+            message.is_system()
             or message.author.bot
             or not isinstance(message.channel, discord.DMChannel)
         ):
@@ -403,7 +412,7 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
         usage="new <message>",
         aliases=["create", "switch", "change"],
     )
-    async def new(self, ctx, *, message: str):
+    async def new(self, ctx: Context, *, message: str) -> None:
         ctx.message.content = message
         ctx.message._data["content"] = message
 
@@ -414,7 +423,7 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
     @commands.command(
         description="Shortcut to send message to a server.", usage="send <server ID> <message>"
     )
-    async def send(self, ctx, guild: GuildConverter, *, message: str):
+    async def send(self, ctx: Context, guild: GuildConverter, *, message: str) -> None:
         ctx.message.content = message
         await self.send_mail(ctx.message, guild)
 
@@ -422,7 +431,7 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
     @commands.command(
         description="Enable or disable the confirmation message.", usage="confirmation"
     )
-    async def confirmation(self, ctx):
+    async def confirmation(self, ctx: Context) -> None:
         data = await tools.get_user_settings(self.bot, ctx.author.id)
 
         if not data or data[0] is True:
@@ -453,5 +462,5 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
         await ctx.send(Embed("Confirmation messages are enabled."))
 
 
-async def setup(bot):
+async def setup(bot: ModMail) -> None:
     await bot.add_cog(DirectMessageEvents(bot))

--- a/cogs/direct_message.py
+++ b/cogs/direct_message.py
@@ -65,7 +65,7 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
                     data[12] if data[12] else "No reason was provided.",
                     timestamp=True,
                 )
-                embed.set_footer(f"{guild.name} | {guild.id}", guild.icon_url)
+                embed.set_footer(f"{guild.name} | {guild.id}", (guild.icon.url if guild.icon else None))
                 await message.channel.send(embed)
                 return
 
@@ -123,7 +123,7 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
                 )
                 embed.set_footer(
                     f"{message.author.name} | {message.author.id}",
-                    message.author.avatar_url,
+                    message.author.display_avatar.url,
                 )
 
                 try:
@@ -162,7 +162,7 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
                 ),
             )
             embed.set_footer(
-                f"{message.author.name} | {message.author.id}", message.author.avatar_url
+                f"{message.author.name} | {message.author.id}", message.author.display_avatar.url
             )
 
             roles = []
@@ -191,12 +191,12 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
                     colour=0xFF4500,
                     timestamp=True,
                 )
-                embed.set_footer(f"{guild.name} | {guild.id}", guild.icon_url)
+                embed.set_footer(f"{guild.name} | {guild.id}", (guild.icon.url if guild.icon else None))
 
                 await message.channel.send(embed)
 
         embed = Embed("Message Sent", message.content, colour=0x00FF00, timestamp=True)
-        embed.set_footer(f"{guild.name} | {guild.id}", guild.icon_url)
+        embed.set_footer(f"{guild.name} | {guild.id}", (guild.icon.url if guild.icon else None))
 
         files = []
         for file in message.attachments:
@@ -209,7 +209,7 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
         embed.title = "Message Received"
         embed.set_footer(
             f"{message.author.name} | {message.author.id}",
-            message.author.avatar_url,
+            message.author.display_avatar.url,
         )
 
         for count, attachment in enumerate(
@@ -325,7 +325,7 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
     @commands.Cog.listener()
     async def on_message(self, message):
         if (
-            message.is_system()
+            message.is_system
             or message.author.bot
             or not isinstance(message.channel, discord.DMChannel)
         ):
@@ -453,5 +453,5 @@ class DirectMessageEvents(commands.Cog, name="Direct Message"):
         await ctx.send(Embed("Confirmation messages are enabled."))
 
 
-def setup(bot):
-    bot.add_cog(DirectMessageEvents(bot))
+async def setup(bot):
+    await bot.add_cog(DirectMessageEvents(bot))

--- a/cogs/error_handler.py
+++ b/cogs/error_handler.py
@@ -93,5 +93,5 @@ class ErrorHandler(commands.Cog):
                 pass
 
 
-def setup(bot):
-    bot.add_cog(ErrorHandler(bot))
+async def setup(bot):
+    await bot.add_cog(ErrorHandler(bot))

--- a/cogs/error_handler.py
+++ b/cogs/error_handler.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import traceback
 
@@ -5,6 +7,8 @@ import discord
 
 from discord.ext import commands
 
+from classes.bot import ModMail
+from classes.context import Context
 from classes.embed import ErrorEmbed
 from utils import tools
 
@@ -12,11 +16,13 @@ log = logging.getLogger(__name__)
 
 
 class ErrorHandler(commands.Cog):
-    def __init__(self, bot):
+    def __init__(self, bot: ModMail) -> None:
         self.bot = bot
         bot.on_command_error = self._on_command_error
 
-    async def _on_command_error(self, ctx, error, bypass=False):
+    async def _on_command_error(
+        self, ctx: Context, error: commands.CommandError, bypass: bool = False
+    ) -> None:
         if (
             hasattr(ctx.command, "on_error")
             or (ctx.command and hasattr(ctx.cog, f"_{ctx.command.cog_name}__error"))
@@ -93,5 +99,5 @@ class ErrorHandler(commands.Cog):
                 pass
 
 
-async def setup(bot):
+async def setup(bot: ModMail) -> None:
     await bot.add_cog(ErrorHandler(bot))

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -1,27 +1,34 @@
+from __future__ import annotations
+
 import logging
 import time
+
+from typing import Any
 
 import discord
 
 from discord.ext import commands
+from discord.http import Route
 
+from classes.bot import ModMail
 from classes.context import Context
 from classes.embed import Embed, ErrorEmbed
+from classes.message import Message
 from utils import tools
 
 log = logging.getLogger(__name__)
 
 
 class Events(commands.Cog):
-    def __init__(self, bot):
+    def __init__(self, bot: ModMail) -> None:
         self.bot = bot
 
     @commands.Cog.listener()
-    async def on_ready(self):
+    async def on_ready(self) -> None:
         pass
 
     @commands.Cog.listener()
-    async def on_raw_reaction_add(self, payload):
+    async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent) -> None:
         if payload.user_id == self.bot.id:
             return
 
@@ -102,41 +109,114 @@ class Events(commands.Cog):
             await self.bot.state.set(f"reaction_menu:{channel.id}:{message.id}", menu)
 
     @commands.Cog.listener()
-    async def on_message(self, message):
+    async def on_interaction_create(self, data: dict[str, Any]) -> None:
+        if data.get("type") != 2:
+            return
+
+        name = data["data"]["name"]
+        options = {x["name"]: str(x["value"]) for x in data["data"].get("options", [])}
+
+        args = ""
+        command = self.bot.get_command(name)
+        if command:
+            for param in command.clean_params.values():
+                value = options.get(param.name.lower())
+                if value is not None:
+                    args += f" {value}"
+
+        try:
+            await self.bot.http.request(
+                Route(
+                    "POST",
+                    "/interactions/{interaction_id}/{interaction_token}/callback",
+                    interaction_id=data["id"],
+                    interaction_token=data["token"],
+                ),
+                json={"type": 5},
+            )
+        except discord.HTTPException:
+            log.warning(f"Failed to acknowledge the {name} slash command.")
+            return
+
+        payload = {
+            "id": data["id"],
+            "channel_id": data["channel_id"],
+            "guild_id": data.get("guild_id"),
+            "author": data["member"]["user"] if data.get("member") else data["user"],
+            "content": f"<@{self.bot.id}> {name}{args}",
+            "edited_timestamp": None,
+            "type": 0,
+            "pinned": False,
+            "mention_everyone": False,
+            "tts": False,
+            "attachments": [],
+            "embeds": [],
+            "_interaction": {
+                "application_id": data["application_id"],
+                "token": data["token"],
+                "responded": False,
+            },
+        }
+
+        if data.get("member"):
+            payload["member"] = data["member"]
+
+        await self.bot.state.parse_message_create(payload, None)
+
+    @commands.Cog.listener()
+    async def on_message(self, message: Message) -> None:
         if message.author.bot:
             return
 
         ctx = await self.bot.get_context(message, cls=Context)
-        if not ctx.command:
-            return
 
-        self.bot.prom.commands.inc({"name": ctx.command.name})
-
-        if message.guild:
-            if await tools.is_guild_banned(self.bot, message.guild):
-                await message.guild.leave()
+        try:
+            if not ctx.command:
                 return
 
-            permissions = await message.channel.permissions_for(await ctx.guild.me())
+            self.bot.prom.commands.inc({"name": ctx.command.name})
 
-            if permissions.send_messages is False:
+            if message.guild:
+                if await tools.is_guild_banned(self.bot, message.guild):
+                    await message.guild.leave()
+                    return
+
+                permissions = await message.channel.permissions_for(await ctx.guild.me())
+
+                if permissions.send_messages is False:
+                    return
+
+                if permissions.embed_links is False:
+                    await message.channel.send(
+                        "The Embed Links permission is needed for basic commands to work."
+                    )
+                    return
+
+            if await tools.is_user_banned(self.bot, message.author):
+                await ctx.send(ErrorEmbed("You are banned from the bot."))
                 return
 
-            if permissions.embed_links is False:
-                await message.channel.send(
-                    "The Embed Links permission is needed for basic commands to work."
-                )
-                return
+            if ctx.prefix in [f"<@{self.bot.id}> ", f"<@!{self.bot.id}> "]:
+                ctx.prefix = await tools.get_guild_prefix(self.bot, message.guild)
 
-        if await tools.is_user_banned(self.bot, message.author):
-            await ctx.send(ErrorEmbed("You are banned from the bot."))
-            return
+            await self.bot.invoke(ctx)
+        finally:
+            interaction = getattr(message, "_interaction", None)
+            if interaction is not None and not interaction.get("responded"):
+                interaction["responded"] = True
+                try:
+                    await self.bot.http.request(
+                        Route(
+                            "PATCH",
+                            "/webhooks/{application_id}/{interaction_token}/messages/@original",
+                            application_id=interaction["application_id"],
+                            interaction_token=interaction["token"],
+                        ),
+                        json={"content": "The command was executed."},
+                    )
+                except discord.HTTPException:
+                    pass
 
-        if ctx.prefix in [f"<@{self.bot.id}> ", f"<@!{self.bot.id}> "]:
-            ctx.prefix = await tools.get_guild_prefix(self.bot, message.guild)
 
-        await self.bot.invoke(ctx)
-
-
-async def setup(bot):
+async def setup(bot: ModMail) -> None:
     await bot.add_cog(Events(bot))

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -138,5 +138,5 @@ class Events(commands.Cog):
         await self.bot.invoke(ctx)
 
 
-def setup(bot):
-    bot.add_cog(Events(bot))
+async def setup(bot):
+    await bot.add_cog(Events(bot))

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -1,6 +1,7 @@
 import logging
 import platform
 import time
+import discord
 
 from datetime import datetime
 
@@ -63,7 +64,7 @@ class General(commands.Cog):
             "can also invite me to your server with the link below, or join our support server if "
             f"you need further help.\n\nTo setup the bot, run `{ctx.prefix}setup`.",
         )
-        page.set_thumbnail(bot_user.avatar_url)
+        page.set_thumbnail(bot_user.display_avatar.url)
         page.set_footer("Use the reactions to flip pages.")
         page.add_field("Invite", f"{self.bot.config.BASE_URI}/invite", False)
         page.add_field("Support Server", "https://discord.gg/wjWJwJB", False)
@@ -85,8 +86,8 @@ class General(commands.Cog):
                 "information on a command.",
             )
 
-            page.set_author("ModMail Help Menu", bot_user.avatar_url)
-            page.set_thumbnail(bot_user.avatar_url)
+            page.set_author("ModMail Help Menu", bot_user.display_avatar.url)
+            page.set_thumbnail(bot_user.display_avatar.url)
             page.set_footer("Use the reactions to flip pages.")
 
             for cmd in cog_commands:
@@ -122,7 +123,7 @@ class General(commands.Cog):
         aliases=["statistics", "info"],
     )
     async def stats(self, ctx):
-        total_seconds = int((datetime.utcnow() - await self.bot.started()).total_seconds())
+        total_seconds = int((discord.utils.utcnow() - await self.bot.started()).total_seconds())
         hours, remainder = divmod(total_seconds, 3600)
         minutes, seconds = divmod(remainder, 60)
         days, hours = divmod(hours, 24)
@@ -149,7 +150,7 @@ class General(commands.Cog):
         embed.add_field("CPU Usage", f"{psutil.cpu_percent(interval=None)}%")
         embed.add_field("RAM Usage", f"{psutil.virtual_memory().percent}%")
         embed.add_field("Python Version", platform.python_version())
-        embed.set_thumbnail(bot_user.avatar_url)
+        embed.set_thumbnail(bot_user.display_avatar.url)
 
         await ctx.send(embed)
 
@@ -180,5 +181,5 @@ class General(commands.Cog):
         await ctx.send(Embed("GitHub Repository", "https://github.com/chamburr/modmail"))
 
 
-def setup(bot):
-    bot.add_cog(General(bot))
+async def setup(bot):
+    await bot.add_cog(General(bot))

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -1,14 +1,16 @@
+from __future__ import annotations
+
 import logging
 import platform
 import time
+
 import discord
-
-from datetime import datetime
-
 import psutil
 
 from discord.ext import commands
 
+from classes.bot import ModMail
+from classes.context import Context
 from classes.embed import Embed
 from utils import checks, tools
 
@@ -16,7 +18,7 @@ log = logging.getLogger(__name__)
 
 
 class General(commands.Cog):
-    def __init__(self, bot):
+    def __init__(self, bot: ModMail) -> None:
         self.bot = bot
 
     @checks.bot_has_permissions(add_reactions=True)
@@ -25,7 +27,7 @@ class General(commands.Cog):
         usage="help [command]",
         aliases=["h", "commands"],
     )
-    async def help(self, ctx, *, command: str = None):
+    async def help(self, ctx: Context, *, command: str | None = None) -> None:
         if command:
             command = self.bot.get_command(command.lower())
             if not command:
@@ -103,7 +105,7 @@ class General(commands.Cog):
         await tools.create_paginator(self.bot, ctx, all_pages)
 
     @commands.command(description="Pong! Get my latency.", usage="ping")
-    async def ping(self, ctx):
+    async def ping(self, ctx: Context) -> None:
         start = time.time()
         shard = ctx.guild.shard_id if ctx.guild else 0
 
@@ -122,7 +124,7 @@ class General(commands.Cog):
         usage="stats",
         aliases=["statistics", "info"],
     )
-    async def stats(self, ctx):
+    async def stats(self, ctx: Context) -> None:
         total_seconds = int((discord.utils.utcnow() - await self.bot.started()).total_seconds())
         hours, remainder = divmod(total_seconds, 3600)
         minutes, seconds = divmod(remainder, 60)
@@ -155,21 +157,21 @@ class General(commands.Cog):
         await ctx.send(embed)
 
     @commands.command(description="See the amazing stuff we have partnered with.", usage="partners")
-    async def partners(self, ctx):
+    async def partners(self, ctx: Context) -> None:
         await ctx.send(Embed("Partners", f"{self.bot.config.BASE_URI}/partners"))
 
     @commands.command(description="Get a link to invite me.", usage="invite")
-    async def invite(self, ctx):
+    async def invite(self, ctx: Context) -> None:
         await ctx.send(Embed("Invite Link", f"{self.bot.config.BASE_URI}/invite"))
 
     @commands.command(
         description="Get a link to my support server.", usage="support", aliases=["server"]
     )
-    async def support(self, ctx):
+    async def support(self, ctx: Context) -> None:
         await ctx.send(Embed("Support Server", "https://discord.gg/wjWJwJB"))
 
     @commands.command(description="Get the link to ModMail's website.", usage="website")
-    async def website(self, ctx):
+    async def website(self, ctx: Context) -> None:
         await ctx.send(Embed("Website", f"{self.bot.config.BASE_URI}"))
 
     @commands.command(
@@ -177,9 +179,9 @@ class General(commands.Cog):
         usage="source",
         aliases=["github"],
     )
-    async def source(self, ctx):
+    async def source(self, ctx: Context) -> None:
         await ctx.send(Embed("GitHub Repository", "https://github.com/chamburr/modmail"))
 
 
-async def setup(bot):
+async def setup(bot: ModMail) -> None:
     await bot.add_cog(General(bot))

--- a/cogs/miscellaneous.py
+++ b/cogs/miscellaneous.py
@@ -57,7 +57,7 @@ class Miscellaneous(commands.Cog):
         embed.add_field("Name", str(member) if member.bot else str(member.name), False)
         embed.add_field("ID", member.id)
         embed.add_field("Nickname", member.nick if member.nick else "*Not set*")
-        embed.add_field("Avatar", f"[Link]({member.avatar_url_as(static_format='png')})")
+        embed.add_field("Avatar", f"[Link]({member.display_avatar.replace(static_format='png').url})")
         embed.add_field(
             "Joined Server",
             f"<t:{round(member.joined_at.timestamp())}:R>" if member.joined_at else "Unknown",
@@ -67,7 +67,7 @@ class Miscellaneous(commands.Cog):
             "Roles",
             f"{len(roles)} roles" if len(", ".join(roles)) > 1000 else ", ".join(roles),
         )
-        embed.set_thumbnail(member.avatar_url)
+        embed.set_thumbnail(member.display_avatar.url)
 
         await ctx.send(embed)
 
@@ -86,7 +86,7 @@ class Miscellaneous(commands.Cog):
         embed.add_field("Owner", f"<@{guild.owner_id}>" if guild.owner_id else "Unknown")
         embed.add_field(
             "Icon",
-            f"[Link]({guild.icon_url_as(static_format='png')})" if guild.icon else "*Not set*",
+            f"[Link]({guild.icon.replace(static_format='png').url})" if guild.icon else "*Not set*",
         )
         embed.add_field("Server Created", f"<t:{round(guild.created_at.timestamp())}:R>")
         embed.add_field("Members", guild.member_count)
@@ -94,10 +94,10 @@ class Miscellaneous(commands.Cog):
         embed.add_field("Roles", str(len(await guild.roles())))
 
         if guild.icon:
-            embed.set_thumbnail(guild.icon_url)
+            embed.set_thumbnail((guild.icon.url if guild.icon else None))
 
         await ctx.send(embed)
 
 
-def setup(bot):
-    bot.add_cog(Miscellaneous(bot))
+async def setup(bot):
+    await bot.add_cog(Miscellaneous(bot))

--- a/cogs/miscellaneous.py
+++ b/cogs/miscellaneous.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
+
 import logging
 
 from discord.ext import commands
 
+from classes.bot import ModMail
+from classes.context import Context
 from classes.embed import Embed
 from utils import checks, tools
 from utils.converters import MemberConverter
@@ -10,7 +14,7 @@ log = logging.getLogger(__name__)
 
 
 class Miscellaneous(commands.Cog):
-    def __init__(self, bot):
+    def __init__(self, bot: ModMail) -> None:
         self.bot = bot
 
     @checks.has_permissions(administrator=True)
@@ -20,7 +24,9 @@ class Miscellaneous(commands.Cog):
         usage="permissions [member]",
         aliases=["perms"],
     )
-    async def permissions(self, ctx, member: MemberConverter = None):
+    async def permissions(
+        self, ctx: Context, member: MemberConverter = None
+    ) -> None:
         if member is None:
             member = ctx.message.member
 
@@ -45,7 +51,9 @@ class Miscellaneous(commands.Cog):
         usage="userinfo [member]",
         aliases=["memberinfo"],
     )
-    async def userinfo(self, ctx, *, member: MemberConverter = None):
+    async def userinfo(
+        self, ctx: Context, *, member: MemberConverter = None
+    ) -> None:
         if member is None:
             member = ctx.message.member
 
@@ -57,7 +65,9 @@ class Miscellaneous(commands.Cog):
         embed.add_field("Name", str(member) if member.bot else str(member.name), False)
         embed.add_field("ID", member.id)
         embed.add_field("Nickname", member.nick if member.nick else "*Not set*")
-        embed.add_field("Avatar", f"[Link]({member.display_avatar.replace(static_format='png').url})")
+        embed.add_field(
+            "Avatar", f"[Link]({member.display_avatar.replace(static_format='png').url})"
+        )
         embed.add_field(
             "Joined Server",
             f"<t:{round(member.joined_at.timestamp())}:R>" if member.joined_at else "Unknown",
@@ -77,7 +87,7 @@ class Miscellaneous(commands.Cog):
         usage="serverinfo",
         aliases=["guildinfo"],
     )
-    async def serverinfo(self, ctx):
+    async def serverinfo(self, ctx: Context) -> None:
         guild = await self.bot.get_guild(ctx.guild.id)
 
         embed = Embed(title="Server Information")
@@ -99,5 +109,5 @@ class Miscellaneous(commands.Cog):
         await ctx.send(embed)
 
 
-async def setup(bot):
+async def setup(bot: ModMail) -> None:
     await bot.add_cog(Miscellaneous(bot))

--- a/cogs/miscellaneous.py
+++ b/cogs/miscellaneous.py
@@ -24,9 +24,7 @@ class Miscellaneous(commands.Cog):
         usage="permissions [member]",
         aliases=["perms"],
     )
-    async def permissions(
-        self, ctx: Context, member: MemberConverter = None
-    ) -> None:
+    async def permissions(self, ctx: Context, member: MemberConverter = None) -> None:
         if member is None:
             member = ctx.message.member
 
@@ -51,9 +49,7 @@ class Miscellaneous(commands.Cog):
         usage="userinfo [member]",
         aliases=["memberinfo"],
     )
-    async def userinfo(
-        self, ctx: Context, *, member: MemberConverter = None
-    ) -> None:
+    async def userinfo(self, ctx: Context, *, member: MemberConverter = None) -> None:
         if member is None:
             member = ctx.message.member
 

--- a/cogs/modmail_channel.py
+++ b/cogs/modmail_channel.py
@@ -72,10 +72,10 @@ class ModMailEvents(commands.Cog):
             message.content = tools.tag_format(message.content, member)
 
         embed = Embed("Message Received", message.content, colour=0xFF4500, timestamp=True)
-        embed.set_footer(f"{message.guild.name} | {message.guild.id}", message.guild.icon_url)
+        embed.set_footer(f"{message.guild.name} | {message.guild.id}", (message.guild.icon.url if message.guild.icon else None))
 
         if anon is False:
-            embed.set_author(str(message.author.name), message.author.avatar_url)
+            embed.set_author(str(message.author.name), message.author.display_avatar.url)
 
         files = []
         for file in message.attachments:
@@ -98,9 +98,9 @@ class ModMailEvents(commands.Cog):
         embed.title = "Message Sent"
         embed.set_author(
             str(message.author.name) if anon is False else f"{message.author.name} (Anonymous)",
-            message.author.avatar_url,
+            message.author.display_avatar.url,
         )
-        embed.set_footer(f"{member.name} | {member.id}", member.avatar_url)
+        embed.set_footer(f"{member.name} | {member.id}", member.display_avatar.url)
 
         for count, attachment in enumerate(
             [attachment.url for attachment in dm_message.attachments], start=1
@@ -118,5 +118,5 @@ class ModMailEvents(commands.Cog):
             pass
 
 
-def setup(bot):
-    bot.add_cog(ModMailEvents(bot))
+async def setup(bot):
+    await bot.add_cog(ModMailEvents(bot))

--- a/cogs/modmail_channel.py
+++ b/cogs/modmail_channel.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import io
 import logging
 
@@ -5,18 +7,20 @@ import discord
 
 from discord.ext import commands
 
+from classes.bot import ModMail
 from classes.embed import Embed, ErrorEmbed
+from classes.message import Message
 from utils import tools
 
 log = logging.getLogger(__name__)
 
 
 class ModMailEvents(commands.Cog):
-    def __init__(self, bot):
+    def __init__(self, bot: ModMail) -> None:
         self.bot = bot
 
     @commands.Cog.listener()
-    async def on_message(self, message):
+    async def on_message(self, message: Message) -> None:
         if message.author.bot or not message.guild or not tools.is_modmail_channel(message.channel):
             return
 
@@ -43,7 +47,9 @@ class ModMailEvents(commands.Cog):
 
         await self.send_mail_mod(message, prefix)
 
-    async def send_mail_mod(self, message, prefix, anon=False, snippet=False):
+    async def send_mail_mod(
+        self, message: Message, prefix: str, anon: bool = False, snippet: bool = False
+    ) -> None:
         self.bot.prom.tickets_message.inc({})
 
         data = await tools.get_data(self.bot, message.guild.id)
@@ -72,7 +78,10 @@ class ModMailEvents(commands.Cog):
             message.content = tools.tag_format(message.content, member)
 
         embed = Embed("Message Received", message.content, colour=0xFF4500, timestamp=True)
-        embed.set_footer(f"{message.guild.name} | {message.guild.id}", (message.guild.icon.url if message.guild.icon else None))
+        embed.set_footer(
+            f"{message.guild.name} | {message.guild.id}",
+            (message.guild.icon.url if message.guild.icon else None),
+        )
 
         if anon is False:
             embed.set_author(str(message.author.name), message.author.display_avatar.url)
@@ -118,5 +127,5 @@ class ModMailEvents(commands.Cog):
             pass
 
 
-async def setup(bot):
+async def setup(bot: ModMail) -> None:
     await bot.add_cog(ModMailEvents(bot))

--- a/cogs/owner.py
+++ b/cogs/owner.py
@@ -170,5 +170,5 @@ class Owner(commands.Cog):
         await ctx.send(Embed("Successfully unbanned that server from the bot."))
 
 
-def setup(bot):
-    bot.add_cog(Owner(bot))
+async def setup(bot):
+    await bot.add_cog(Owner(bot))

--- a/cogs/owner.py
+++ b/cogs/owner.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 import copy
 import io
 import logging
 import subprocess
 import textwrap
 import traceback
-import typing
 
 from contextlib import redirect_stdout
 
@@ -12,6 +13,8 @@ import discord
 
 from discord.ext import commands
 
+from classes.bot import ModMail
+from classes.context import Context
 from classes.embed import Embed, ErrorEmbed
 from utils import checks
 from utils.converters import ChannelConverter, GuildConverter, MemberConverter, UserConverter
@@ -20,12 +23,12 @@ log = logging.getLogger(__name__)
 
 
 class Owner(commands.Cog):
-    def __init__(self, bot):
+    def __init__(self, bot: ModMail) -> None:
         self.bot = bot
 
     @checks.is_owner()
     @commands.command(name="eval", description="Evaluate code.", usage="eval <code>")
-    async def _eval(self, ctx, *, body: str):
+    async def _eval(self, ctx: Context, *, body: str) -> None:
         env = {
             "bot": self.bot,
             "ctx": ctx,
@@ -70,7 +73,7 @@ class Owner(commands.Cog):
 
     @checks.is_owner()
     @commands.command(description="Execute code in bash.", usage="bash <command>")
-    async def bash(self, ctx, *, command: str):
+    async def bash(self, ctx: Context, *, command: str) -> None:
         try:
             output = subprocess.check_output(command.split(), stderr=subprocess.STDOUT).decode(
                 "utf-8"
@@ -81,7 +84,7 @@ class Owner(commands.Cog):
 
     @checks.is_owner()
     @commands.command(description="Execute SQL query.", usage="sql <query>")
-    async def sql(self, ctx, *, query: str):
+    async def sql(self, ctx: Context, *, query: str) -> None:
         async with self.bot.pool.acquire() as conn:
             try:
                 res = await conn.fetch(query)
@@ -102,12 +105,12 @@ class Owner(commands.Cog):
     )
     async def invoke(
         self,
-        ctx,
-        channel: typing.Optional[ChannelConverter],
+        ctx: Context,
+        channel: ChannelConverter | None,
         member: MemberConverter,
         *,
         command: str,
-    ):
+    ) -> None:
         msg = copy.copy(ctx.message)
         channel = channel or ctx.channel
         msg.channel = channel
@@ -119,7 +122,7 @@ class Owner(commands.Cog):
 
     @checks.is_owner()
     @commands.command(description="Ban a user from the bot", usage="banuser <user>")
-    async def banuser(self, ctx, *, user: UserConverter):
+    async def banuser(self, ctx: Context, *, user: UserConverter) -> None:
         async with self.bot.pool.acquire() as conn:
             await conn.execute("INSERT INTO ban VALUES ($1, $2)", user.id, 0)
 
@@ -129,7 +132,7 @@ class Owner(commands.Cog):
 
     @checks.is_owner()
     @commands.command(description="Unban a user from the bot", usage="unbanuser <user>")
-    async def unbanuser(self, ctx, *, user: UserConverter):
+    async def unbanuser(self, ctx: Context, *, user: UserConverter) -> None:
         async with self.bot.pool.acquire() as conn:
             res = await conn.execute(
                 "DELETE FROM ban WHERE identifier=$1 AND category=$2", user.id, 0
@@ -145,7 +148,7 @@ class Owner(commands.Cog):
 
     @checks.is_owner()
     @commands.command(description="Ban a server from the bot", usage="banserver <server ID>")
-    async def banserver(self, ctx, *, guild: GuildConverter):
+    async def banserver(self, ctx: Context, *, guild: GuildConverter) -> None:
         async with self.bot.pool.acquire() as conn:
             await conn.execute("INSERT INTO ban VALUES ($1, $2)", guild.id, 1)
 
@@ -155,7 +158,7 @@ class Owner(commands.Cog):
 
     @checks.is_owner()
     @commands.command(description="Unban a server from the bot", usage="unbanserver <server ID>")
-    async def unbanserver(self, ctx, *, guild: int):
+    async def unbanserver(self, ctx: Context, *, guild: int) -> None:
         async with self.bot.pool.acquire() as conn:
             res = await conn.execute(
                 "DELETE FROM ban WHERE identifier=$1 AND category=$2", guild, 1
@@ -170,5 +173,5 @@ class Owner(commands.Cog):
         await ctx.send(Embed("Successfully unbanned that server from the bot."))
 
 
-async def setup(bot):
+async def setup(bot: ModMail) -> None:
     await bot.add_cog(Owner(bot))

--- a/cogs/premium.py
+++ b/cogs/premium.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
+
 import logging
 
 from discord.ext import commands
 
+from classes.bot import ModMail
+from classes.context import Context
 from classes.embed import Embed, ErrorEmbed
 from utils import checks, tools
 from utils.converters import GuildConverter
@@ -10,7 +14,7 @@ log = logging.getLogger(__name__)
 
 
 class Premium(commands.Cog):
-    def __init__(self, bot):
+    def __init__(self, bot: ModMail) -> None:
         self.bot = bot
 
     @commands.command(
@@ -18,7 +22,7 @@ class Premium(commands.Cog):
         usage="premium",
         aliases=["donate", "patron"],
     )
-    async def premium(self, ctx):
+    async def premium(self, ctx: Context) -> None:
         embed = Embed(
             "Premium",
             "Purchasing premium is the best way you can show support to us. As hosting this bot "
@@ -44,7 +48,7 @@ class Premium(commands.Cog):
     @checks.is_premium()
     @commands.guild_only()
     @commands.command(description="Get the premium status of this server.", usage="premiumstatus")
-    async def premiumstatus(self, ctx):
+    async def premiumstatus(self, ctx: Context) -> None:
         async with self.bot.pool.acquire() as conn:
             res = await conn.fetchrow(
                 "SELECT identifier FROM premium WHERE $1=any(guild)", ctx.guild.id
@@ -57,12 +61,13 @@ class Premium(commands.Cog):
         await ctx.send(Embed(f"This server has premium. Offered by: <@{res[0]}>."))
 
     @checks.is_patron()
+    @commands.guild_only()
     @commands.command(
         description="View a list of servers you assigned premium to.",
         usage="viewpremium",
         aliases=["premiumlist"],
     )
-    async def viewpremium(self, ctx):
+    async def viewpremium(self, ctx: Context) -> None:
         async with self.bot.pool.acquire() as conn:
             res = await conn.fetchrow(
                 "SELECT guild FROM premium WHERE identifier=$1", ctx.author.id
@@ -80,10 +85,13 @@ class Premium(commands.Cog):
         await ctx.send(Embed("Premium Servers", "\n".join(guilds)))
 
     @checks.is_patron()
+    @commands.guild_only()
     @commands.command(
         description="Assign premium slot to a server.", usage="premiumassign [server ID]"
     )
-    async def premiumassign(self, ctx, *, guild: GuildConverter = None):
+    async def premiumassign(
+        self, ctx: Context, *, guild: GuildConverter = None
+    ) -> None:
         if guild is None:
             guild = ctx.guild
 
@@ -120,10 +128,13 @@ class Premium(commands.Cog):
         await ctx.send(Embed("The server now has premium."))
 
     @checks.is_patron()
+    @commands.guild_only()
     @commands.command(
         description="Remove premium slot from a server.", usage="premiumremove [server ID]"
     )
-    async def premiumremove(self, ctx, *, guild: int = None):
+    async def premiumremove(
+        self, ctx: Context, *, guild: int = None
+    ) -> None:
         if guild is None:
             guild = ctx.guild.id
 
@@ -150,5 +161,5 @@ class Premium(commands.Cog):
         await ctx.send(Embed("The server no longer has premium."))
 
 
-async def setup(bot):
+async def setup(bot: ModMail) -> None:
     await bot.add_cog(Premium(bot))

--- a/cogs/premium.py
+++ b/cogs/premium.py
@@ -150,5 +150,5 @@ class Premium(commands.Cog):
         await ctx.send(Embed("The server no longer has premium."))
 
 
-def setup(bot):
-    bot.add_cog(Premium(bot))
+async def setup(bot):
+    await bot.add_cog(Premium(bot))

--- a/cogs/premium.py
+++ b/cogs/premium.py
@@ -89,9 +89,7 @@ class Premium(commands.Cog):
     @commands.command(
         description="Assign premium slot to a server.", usage="premiumassign [server ID]"
     )
-    async def premiumassign(
-        self, ctx: Context, *, guild: GuildConverter = None
-    ) -> None:
+    async def premiumassign(self, ctx: Context, *, guild: GuildConverter = None) -> None:
         if guild is None:
             guild = ctx.guild
 
@@ -132,9 +130,7 @@ class Premium(commands.Cog):
     @commands.command(
         description="Remove premium slot from a server.", usage="premiumremove [server ID]"
     )
-    async def premiumremove(
-        self, ctx: Context, *, guild: int = None
-    ) -> None:
+    async def premiumremove(self, ctx: Context, *, guild: int = None) -> None:
         if guild is None:
             guild = ctx.guild.id
 

--- a/cogs/snippet.py
+++ b/cogs/snippet.py
@@ -1,10 +1,13 @@
+from __future__ import annotations
+
 import logging
 
 import asyncpg
-import discord
 
 from discord.ext import commands
 
+from classes.bot import ModMail
+from classes.context import Context
 from classes.embed import Embed, ErrorEmbed
 from utils import checks, tools
 
@@ -12,7 +15,7 @@ log = logging.getLogger(__name__)
 
 
 class Snippet(commands.Cog):
-    def __init__(self, bot):
+    def __init__(self, bot: ModMail) -> None:
         self.bot = bot
 
     @checks.is_modmail_channel()
@@ -21,7 +24,7 @@ class Snippet(commands.Cog):
     @checks.is_mod()
     @commands.guild_only()
     @commands.command(description="Use a snippet.", aliases=["s"], usage="snippet <name>")
-    async def snippet(self, ctx, *, name: str):
+    async def snippet(self, ctx: Context, *, name: str) -> None:
         async with self.bot.pool.acquire() as conn:
             res = await conn.fetchrow(
                 "SELECT content FROM snippet WHERE name=$1 AND guild=$2", name.lower(), ctx.guild.id
@@ -44,7 +47,7 @@ class Snippet(commands.Cog):
     @commands.command(
         description="Use a snippet anonymously.", aliases=["as"], usage="asnippet <name>"
     )
-    async def asnippet(self, ctx, *, name: str):
+    async def asnippet(self, ctx: Context, *, name: str) -> None:
         async with self.bot.pool.acquire() as conn:
             res = await conn.fetchrow(
                 "SELECT content FROM snippet WHERE name=$1 AND guild=$2", name.lower(), ctx.guild.id
@@ -68,7 +71,7 @@ class Snippet(commands.Cog):
         "can be used.",
         usage="snippetadd <name> <content>",
     )
-    async def snippetadd(self, ctx, name: str, *, content: str):
+    async def snippetadd(self, ctx: Context, name: str, *, content: str) -> None:
         if len(name) > 100:
             await ctx.send(ErrorEmbed("The snippet name cannot exceed 100 characters."))
             return
@@ -97,7 +100,7 @@ class Snippet(commands.Cog):
     @checks.is_mod()
     @commands.guild_only()
     @commands.command(description="Remove a snippet.", usage="snippetremove <name>")
-    async def snippetremove(self, ctx, *, name: str):
+    async def snippetremove(self, ctx: Context, *, name: str) -> None:
         async with self.bot.pool.acquire() as conn:
             res = await conn.execute(
                 "DELETE FROM snippet WHERE name=$1 AND guild=$2", name, ctx.guild.id
@@ -114,7 +117,7 @@ class Snippet(commands.Cog):
     @checks.is_mod()
     @commands.guild_only()
     @commands.command(description="Remove all the snippets.", usage="snippetclear")
-    async def snippetclear(self, ctx):
+    async def snippetclear(self, ctx: Context) -> None:
         async with self.bot.pool.acquire() as conn:
             await conn.execute("DELETE FROM snippet WHERE guild=$1", ctx.guild.id)
 
@@ -130,7 +133,7 @@ class Snippet(commands.Cog):
         aliases=["viewsnippets", "snippetlist", "vs"],
         usage="viewsnippet [name]",
     )
-    async def viewsnippet(self, ctx, *, name: str = None):
+    async def viewsnippet(self, ctx: Context, *, name: str | None = None) -> None:
         if name:
             async with self.bot.pool.acquire() as conn:
                 res = await conn.fetchrow(
@@ -180,5 +183,5 @@ class Snippet(commands.Cog):
         await tools.create_paginator(self.bot, ctx, all_pages)
 
 
-async def setup(bot):
+async def setup(bot: ModMail) -> None:
     await bot.add_cog(Snippet(bot))

--- a/cogs/snippet.py
+++ b/cogs/snippet.py
@@ -173,12 +173,12 @@ class Snippet(commands.Cog):
 
         if len(all_pages) == 1:
             embed = all_pages[0]
-            embed.set_footer(discord.Embed.Empty)
+            embed.set_footer(None)
             await ctx.send(embed)
             return
 
         await tools.create_paginator(self.bot, ctx, all_pages)
 
 
-def setup(bot):
-    bot.add_cog(Snippet(bot))
+async def setup(bot):
+    await bot.add_cog(Snippet(bot))

--- a/main.py
+++ b/main.py
@@ -109,7 +109,7 @@ class Scheduler:
             async with self.bot.pool.acquire() as conn:
                 premium = await conn.fetch(
                     "SELECT identifier, guild FROM premium WHERE expiry IS NOT NULL AND expiry<$1",
-                    int(datetime.utcnow().timestamp() * 1000),
+                    int(discord.utils.utcnow().timestamp() * 1000),
                 )
 
                 for row in premium:

--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import json
 import os
@@ -5,8 +7,9 @@ import signal
 import sys
 import time
 
-from datetime import datetime
+from collections.abc import Awaitable, Callable
 from pathlib import Path
+from typing import Any
 
 import aiohttp
 import discord
@@ -24,7 +27,7 @@ VERSION = "3.4.0"
 
 
 class Instance:
-    def __init__(self, instance_id, loop, main):
+    def __init__(self, instance_id: int, loop: asyncio.AbstractEventLoop, main: Main) -> None:
         self.id = instance_id
         self.loop = loop
         self.main = main
@@ -34,10 +37,10 @@ class Instance:
         self.task.add_done_callback(self.main.dead_process_handler)
 
     @property
-    def is_active(self):
+    def is_active(self) -> bool:
         return self._process is not None and not self._process.returncode
 
-    async def read_stream(self, stream):
+    async def read_stream(self, stream: asyncio.StreamReader) -> None:
         while self.is_active:
             try:
                 line = await stream.readline()
@@ -50,7 +53,7 @@ class Instance:
             else:
                 break
 
-    async def start(self):
+    async def start(self) -> Instance | None:
         if self.is_active:
             print(f"[Cluster {self.id}] Already active.")
             return
@@ -76,11 +79,11 @@ class Instance:
 
         return self
 
-    def kill(self):
+    def kill(self) -> None:
         self.status = "stopped"
         os.killpg(os.getpgid(self._process.pid), signal.SIGTERM)
 
-    async def restart(self):
+    async def restart(self) -> None:
         if self.is_active:
             self.kill()
             await asyncio.sleep(1)
@@ -89,12 +92,12 @@ class Instance:
 
 
 class Scheduler:
-    def __init__(self, loop, bot):
+    def __init__(self, loop: asyncio.AbstractEventLoop, bot: ModMail) -> None:
         self.loop = loop
         self.bot = bot
         self.session = aiohttp.ClientSession()
 
-    async def run_task(self, task):
+    async def run_task(self, task: Callable[[], Awaitable[Any]]) -> None:
         while True:
             try:
                 await task()
@@ -104,7 +107,7 @@ class Scheduler:
                 print(f"[Cluster Manager] Task {task.__name__} crashed: {e}")
                 await asyncio.sleep(10)
 
-    async def premium_updater(self):
+    async def premium_updater(self) -> None:
         while True:
             async with self.bot.pool.acquire() as conn:
                 premium = await conn.fetch(
@@ -129,7 +132,7 @@ class Scheduler:
 
             await asyncio.sleep(60)
 
-    async def bot_stats_updater(self):
+    async def bot_stats_updater(self) -> None:
         while True:
             guilds = await self.bot.state.scard("guild_keys")
             shards = await self.bot.shard_count()
@@ -160,7 +163,7 @@ class Scheduler:
 
             await asyncio.sleep(900)
 
-    async def cleanup(self):
+    async def cleanup(self) -> None:
         while True:
             for menu_key in await self.bot.state.smembers("reaction_menu_keys"):
                 menu = await self.bot.state.get(menu_key)
@@ -227,7 +230,7 @@ class Scheduler:
 
             await asyncio.sleep(30)
 
-    async def launch(self):
+    async def launch(self) -> None:
         if config.ENVIRONMENT == "production":
             self.loop.create_task(self.run_task(self.bot_stats_updater))
 
@@ -236,13 +239,13 @@ class Scheduler:
 
 
 class Main:
-    def __init__(self, loop):
+    def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
         self.loop = loop
-        self.instances = []
-        self.bot = None
+        self.instances: list[Instance] = []
+        self.bot: ModMail = discord.utils.MISSING
         self.shard_count = None
 
-    def dead_process_handler(self, result):
+    def dead_process_handler(self, result: asyncio.Task[Any]) -> None:
         instance = result.result()
         print(
             f"[Cluster {instance.id}] The cluster exited with code {instance._process.returncode}."
@@ -255,7 +258,7 @@ class Main:
         print(f"[Cluster {instance.id}] The cluster is restarting.")
         instance.loop.create_task(instance.start())
 
-    async def user_select_handler(self, body):
+    async def user_select_handler(self, body: dict[str, Any]) -> None:
         async with self.bot.pool.acquire() as conn:
             await conn.execute(
                 "INSERT INTO account VALUES ($1, TRUE, $2) ON CONFLICT (identifier) DO UPDATE SET "
@@ -276,7 +279,7 @@ class Main:
 
         await tools.select_guild(self.bot, message, msg)
 
-    async def handler(self, request):
+    async def handler(self, request: web.BaseRequest) -> web.Response | None:
         if request.method == "GET" and request.path == "/healthcheck":
             return web.Response(body='{"status":"Ok"}', content_type="application/json")
         elif request.method == "GET" and request.path == "/restart":
@@ -288,7 +291,7 @@ class Main:
             self.loop.create_task(self.user_select_handler(body))
             return web.Response(body='{"status":"Ok"}', content_type="application/json")
 
-    def write_targets(self):
+    def write_targets(self) -> None:
         data = []
 
         data.append({"labels": {"cluster": "0"}, "targets": ["localhost:6100"]})
@@ -298,7 +301,7 @@ class Main:
         with open("targets.json", "w") as file:
             json.dump(data, file, indent=2)
 
-    async def load_cache(self):
+    async def load_cache(self) -> None:
         async with self.bot.pool.acquire() as conn:
             data = await conn.fetch("SELECT guild, prefix FROM data")
             bans = await conn.fetch("SELECT identifier, category FROM ban")
@@ -314,7 +317,7 @@ class Main:
         if len([x[0] for x in bans if x[1] == 1]) >= 1:
             await self.bot.state.sadd("banned_guilds", *[x[0] for x in bans if x[1] == 1])
 
-    async def launch(self):
+    async def launch(self) -> None:
         print(f"[Cluster Manager] Starting a total of {config.BOT_CLUSTERS} clusters.")
 
         self.bot = ModMail(cluster_id=0, cluster_count=int(config.BOT_CLUSTERS))
@@ -350,7 +353,7 @@ try:
     loop.run_forever()
 except KeyboardInterrupt:
 
-    def shutdown_handler(_loop, context):
+    def shutdown_handler(_loop: asyncio.AbstractEventLoop, context: dict[str, Any]) -> None:
         if "exception" not in context or not isinstance(
             context["exception"], asyncio.CancelledError
         ):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aio-pika==9.4.0
-aiohttp==3.7.4.post0
+aiohttp>=3.10.0
 aioprometheus==23.3.0
 aioredis==1.3.1
 asyncpg==0.29.0
@@ -9,5 +9,4 @@ orjson==3.9.13
 psutil==5.9.8
 python-dotenv==1.0.1
 subprocess32==3.5.4
-
-git+https://github.com/chamburr/discord.py.git
+discord.py==2.7.1

--- a/utils/checks.py
+++ b/utils/checks.py
@@ -1,4 +1,8 @@
+from __future__ import annotations
+
 import logging
+
+from typing import TYPE_CHECKING
 
 from discord.ext import commands
 from discord.ext.commands import BotMissingPermissions, MissingPermissions
@@ -7,12 +11,17 @@ from classes.channel import TextChannel
 from classes.embed import ErrorEmbed
 from utils import tools
 
+if TYPE_CHECKING:
+    from discord.ext.commands._types import Check
+
+    from classes.context import Context
+
 log = logging.getLogger(__name__)
 
 
-def is_owner():
-    def predicate(ctx):
-        if str(ctx.author.id) not in ctx.bot.config.OWNER_USERS.split(","):
+def is_owner() -> Check[Context]:
+    def predicate(ctx: Context) -> bool:
+        if str(ctx.author.id) not in (ctx.bot.config.OWNER_USERS or "").split(","):
             raise commands.NotOwner()
 
         return True
@@ -20,10 +29,11 @@ def is_owner():
     return commands.check(predicate)
 
 
-def is_admin():
-    def predicate(ctx):
+def is_admin() -> Check[Context]:
+    def predicate(ctx: Context) -> bool:
         if str(ctx.author.id) not in (
-            ctx.bot.config.OWNER_USERS.split(",") + ctx.bot.config.ADMIN_USERS.split(",")
+            (ctx.bot.config.OWNER_USERS or "").split(",")
+            + (ctx.bot.config.ADMIN_USERS or "").split(",")
         ):
             raise commands.NotOwner()
 
@@ -32,8 +42,8 @@ def is_admin():
     return commands.check(predicate)
 
 
-def in_database():
-    async def predicate(ctx):
+def in_database() -> Check[Context]:
+    async def predicate(ctx: Context) -> bool:
         async with ctx.bot.pool.acquire() as conn:
             res = await conn.fetchrow("SELECT category FROM data WHERE guild=$1", ctx.guild.id)
 
@@ -48,8 +58,8 @@ def in_database():
     return commands.check(predicate)
 
 
-def is_premium():
-    async def predicate(ctx):
+def is_premium() -> Check[Context]:
+    async def predicate(ctx: Context) -> bool:
         if not ctx.bot.config.MAIN_SERVER:
             return True
 
@@ -72,8 +82,8 @@ def is_premium():
     return commands.check(predicate)
 
 
-def is_patron():
-    async def predicate(ctx):
+def is_patron() -> Check[Context]:
+    async def predicate(ctx: Context) -> bool:
         async with ctx.bot.pool.acquire() as conn:
             res = await conn.fetchrow(
                 "SELECT identifier FROM premium WHERE identifier=$1", ctx.author.id
@@ -99,8 +109,8 @@ def is_patron():
     return commands.check(predicate)
 
 
-def is_modmail_channel():
-    async def predicate(ctx):
+def is_modmail_channel() -> Check[Context]:
+    async def predicate(ctx: Context) -> bool:
         if not tools.is_modmail_channel(ctx.channel):
             await ctx.send(ErrorEmbed("This channel is not a ModMail channel."))
             return False
@@ -110,8 +120,8 @@ def is_modmail_channel():
     return commands.check(predicate)
 
 
-def is_mod():
-    async def predicate(ctx):
+def is_mod() -> Check[Context]:
+    async def predicate(ctx: Context) -> bool:
         if (await ctx.message.member.guild_permissions()).administrator:
             return True
 
@@ -125,8 +135,8 @@ def is_mod():
     return commands.check(predicate)
 
 
-def has_permissions(**perms):
-    async def predicate(ctx):
+def has_permissions(**perms: bool) -> Check[Context]:
+    async def predicate(ctx: Context) -> bool:
         permissions = await ctx.channel.permissions_for(ctx.message.member)
         missing = [perm for perm, value in perms.items() if getattr(permissions, perm) != value]
 
@@ -138,8 +148,8 @@ def has_permissions(**perms):
     return commands.check(predicate)
 
 
-def bot_has_permissions(**perms):
-    async def predicate(ctx):
+def bot_has_permissions(**perms: bool) -> Check[Context]:
+    async def predicate(ctx: Context) -> bool:
         if not isinstance(ctx.channel, TextChannel):
             return True
 

--- a/utils/config.py
+++ b/utils/config.py
@@ -1,18 +1,20 @@
+from __future__ import annotations
+
 import os
 
 from dotenv import load_dotenv
 
 
 class Config:
-    def __init__(self):
+    def __init__(self) -> None:
         pass
 
-    def __getattr__(self, attr):
+    def __getattr__(self, attr: str) -> str | None:
         variable = os.getenv(attr)
         if variable == "":
             return None
         return variable
 
-    def load(self):
+    def load(self) -> Config:
         load_dotenv(override=True)
         return self

--- a/utils/converters.py
+++ b/utils/converters.py
@@ -31,9 +31,7 @@ log = logging.getLogger(__name__)
 
 
 class ChannelConverter(commands.TextChannelConverter):
-    async def convert(
-        self, ctx: Context, argument: str
-    ) -> TextChannel:
+    async def convert(self, ctx: Context, argument: str) -> TextChannel:
         match = self._get_id_match(argument) or re.match(r"<#([0-9]+)>$", argument)
         if match:
             channel_id = int(match.group(1))
@@ -50,9 +48,7 @@ class ChannelConverter(commands.TextChannelConverter):
 
 
 class DateTimeConverter(commands.Converter[datetime.datetime]):
-    async def convert(
-        self, ctx: Context, argument: str
-    ) -> datetime.datetime:
+    async def convert(self, ctx: Context, argument: str) -> datetime.datetime:
         date = dateparser.parse(
             argument,
             settings={
@@ -71,9 +67,7 @@ class DateTimeConverter(commands.Converter[datetime.datetime]):
 
 
 class GuildConverter(commands.GuildConverter):
-    async def convert(
-        self, ctx: Context, argument: str
-    ) -> Guild:
+    async def convert(self, ctx: Context, argument: str) -> Guild:
         try:
             guild = await ctx.bot.get_guild(int(argument))
             if guild:
@@ -85,15 +79,11 @@ class GuildConverter(commands.GuildConverter):
 
 
 class MemberConverter(commands.MemberConverter):
-    async def convert(
-        self, ctx: Context, argument: str
-    ) -> Member:
+    async def convert(self, ctx: Context, argument: str) -> Member:
         match = self._get_id_match(argument) or re.match(r"<@!?([0-9]+)>$", argument)
         if match:
             try:
-                return await ctx.guild.fetch_member(
-                    int(match.group(1))
-                )
+                return await ctx.guild.fetch_member(int(match.group(1)))
             except discord.NotFound:
                 pass
 
@@ -105,9 +95,7 @@ class MemberConverter(commands.MemberConverter):
 
 
 class RoleConverter(commands.RoleConverter):
-    async def convert(
-        self, ctx: Context, argument: str
-    ) -> Role:
+    async def convert(self, ctx: Context, argument: str) -> Role:
         if not ctx.guild:
             raise NoPrivateMessage()
 
@@ -125,9 +113,7 @@ class RoleConverter(commands.RoleConverter):
 
 
 class PingRoleConverter(RoleConverter):
-    async def convert(
-        self, ctx: Context, argument: str
-    ) -> Role | str:
+    async def convert(self, ctx: Context, argument: str) -> Role | str:
         try:
             return await super().convert(ctx, argument)
         except commands.BadArgument:
@@ -135,9 +121,7 @@ class PingRoleConverter(RoleConverter):
 
 
 class UserConverter(commands.UserConverter):
-    async def convert(
-        self, ctx: Context, argument: str
-    ) -> discord.User:
+    async def convert(self, ctx: Context, argument: str) -> discord.User:
         match = self._get_id_match(argument) or re.match(r"<@!?([0-9]+)>$", argument)
         if match:
             try:

--- a/utils/converters.py
+++ b/utils/converters.py
@@ -1,5 +1,10 @@
+from __future__ import annotations
+
+import datetime
 import logging
 import re
+
+from typing import TYPE_CHECKING
 
 import dateparser
 import discord
@@ -13,15 +18,22 @@ from discord.ext.commands.errors import (
     RoleNotFound,
     UserNotFound,
 )
+from discord.role import Role
 
 from classes.channel import TextChannel
 from classes.member import Member
+
+if TYPE_CHECKING:
+    from classes.context import Context
+    from classes.guild import Guild
 
 log = logging.getLogger(__name__)
 
 
 class ChannelConverter(commands.TextChannelConverter):
-    async def convert(self, ctx, argument):
+    async def convert(
+        self, ctx: Context, argument: str
+    ) -> TextChannel:
         match = self._get_id_match(argument) or re.match(r"<#([0-9]+)>$", argument)
         if match:
             channel_id = int(match.group(1))
@@ -37,8 +49,10 @@ class ChannelConverter(commands.TextChannelConverter):
         raise ChannelNotFound(argument)
 
 
-class DateTimeConverter(commands.Converter):
-    async def convert(self, ctx, argument):
+class DateTimeConverter(commands.Converter[datetime.datetime]):
+    async def convert(
+        self, ctx: Context, argument: str
+    ) -> datetime.datetime:
         date = dateparser.parse(
             argument,
             settings={
@@ -57,7 +71,9 @@ class DateTimeConverter(commands.Converter):
 
 
 class GuildConverter(commands.GuildConverter):
-    async def convert(self, ctx, argument):
+    async def convert(
+        self, ctx: Context, argument: str
+    ) -> Guild:
         try:
             guild = await ctx.bot.get_guild(int(argument))
             if guild:
@@ -69,11 +85,15 @@ class GuildConverter(commands.GuildConverter):
 
 
 class MemberConverter(commands.MemberConverter):
-    async def convert(self, ctx, argument):
+    async def convert(
+        self, ctx: Context, argument: str
+    ) -> Member:
         match = self._get_id_match(argument) or re.match(r"<@!?([0-9]+)>$", argument)
         if match:
             try:
-                return await ctx.guild.fetch_member(int(match.group(1)))
+                return await ctx.guild.fetch_member(
+                    int(match.group(1))
+                )
             except discord.NotFound:
                 pass
 
@@ -85,7 +105,9 @@ class MemberConverter(commands.MemberConverter):
 
 
 class RoleConverter(commands.RoleConverter):
-    async def convert(self, ctx, argument):
+    async def convert(
+        self, ctx: Context, argument: str
+    ) -> Role:
         if not ctx.guild:
             raise NoPrivateMessage()
 
@@ -103,7 +125,9 @@ class RoleConverter(commands.RoleConverter):
 
 
 class PingRoleConverter(RoleConverter):
-    async def convert(self, ctx, argument):
+    async def convert(
+        self, ctx: Context, argument: str
+    ) -> Role | str:
         try:
             return await super().convert(ctx, argument)
         except commands.BadArgument:
@@ -111,7 +135,9 @@ class PingRoleConverter(RoleConverter):
 
 
 class UserConverter(commands.UserConverter):
-    async def convert(self, ctx, argument):
+    async def convert(
+        self, ctx: Context, argument: str
+    ) -> discord.User:
         match = self._get_id_match(argument) or re.match(r"<@!?([0-9]+)>$", argument)
         if match:
             try:

--- a/utils/prometheus.py
+++ b/utils/prometheus.py
@@ -1,15 +1,22 @@
+from __future__ import annotations
+
 import asyncio
 import gc
 import os
 import platform
 import resource
 
-from aioprometheus import Counter, Gauge
+from typing import TYPE_CHECKING
+
+from aioprometheus.collectors import Counter, Gauge
 from aioprometheus.service import Service
+
+if TYPE_CHECKING:
+    from classes.bot import ModMail
 
 
 class Prometheus:
-    def __init__(self, bot):
+    def __init__(self, bot: ModMail) -> None:
         self.bot = bot
 
         self.msvr = Service()
@@ -43,7 +50,7 @@ class Prometheus:
         self.tickets = Counter("modmail_tickets", "Number of tickets created.")
         self.tickets_message = Counter("modmail_tickets_message", "Number of ticket messages sent.")
 
-    async def start(self):
+    async def start(self) -> None:
         await self.msvr.start(addr="127.0.0.1", port=6100 + self.bot.cluster)
         self.msvr._runner._server._kwargs["access_log"] = None
 
@@ -51,7 +58,7 @@ class Prometheus:
             self.bot.loop.create_task(self.update_process_stats())
             self.bot.loop.create_task(self.update_platform_stats())
 
-    async def update_process_stats(self):
+    async def update_process_stats(self) -> None:
         while True:
             with open(os.path.join(self.pid, "stat"), "rb") as stat:
                 parts = stat.read().split(b")")[-1].split()
@@ -64,7 +71,7 @@ class Prometheus:
 
             await asyncio.sleep(5)
 
-    async def update_platform_stats(self):
+    async def update_platform_stats(self) -> None:
         while True:
             self.info.set(
                 {

--- a/utils/tools.py
+++ b/utils/tools.py
@@ -1,20 +1,31 @@
+from __future__ import annotations
+
 import logging
 import time
+import typing
+
+from typing import TYPE_CHECKING, Any
 
 import discord
 
+from discord.ext import commands
 from discord.http import Route
 from discord.user import User
 
-from classes.channel import DMChannel
+from classes.channel import DMChannel, TextChannel
 from classes.embed import Embed, ErrorEmbed
 from classes.http import HTTPClient
 from classes.message import Message
 
+if TYPE_CHECKING:
+    from classes.bot import ModMail
+    from classes.context import Context
+    from classes.guild import Guild
+
 log = logging.getLogger(__name__)
 
 
-def create_fake_user(user_id):
+def create_fake_user(user_id: int | str | None) -> User:
     return User(
         state=None,
         data={
@@ -26,11 +37,11 @@ def create_fake_user(user_id):
     )
 
 
-def create_fake_channel(bot, channel_id):
+def create_fake_channel(bot: ModMail, channel_id: int | str) -> DMChannel:
     return DMChannel(me=bot.user, state=bot.state, data={"id": channel_id})
 
 
-def create_fake_message(bot, channel, message_id):
+def create_fake_message(bot: ModMail, channel: DMChannel, message_id: int) -> Message:
     return Message(
         state=bot.state,
         channel=channel,
@@ -49,10 +60,68 @@ def create_fake_message(bot, channel, message_id):
     )
 
 
-async def create_paginator(bot, ctx, pages):
+def _slash_param_required(param: commands.Parameter) -> bool:
+    if param.default is not param.empty:
+        return False
+
+    if typing.get_origin(param.annotation) is typing.Union and type(None) in typing.get_args(
+        param.annotation
+    ):
+        return False
+
+    return True
+
+
+def build_slash_commands(bot: ModMail) -> list[dict[str, Any]]:
+    payload = []
+
+    for command in bot.commands:
+        if command.cog_name in ["Admin", "Owner"]:
+            continue
+
+        description = command.description or command.name
+        if len(description) > 100:
+            description = description[:97] + "..."
+
+        options = []
+        for param in command.clean_params.values():
+            options.append(
+                {
+                    "type": 3,
+                    "name": param.name.lower(),
+                    "description": f"The {param.name}.",
+                    "required": _slash_param_required(param),
+                }
+            )
+
+        options.sort(key=lambda option: not option["required"])
+
+        qualnames = [getattr(check, "__qualname__", "") for check in command.checks]
+        if any(qualname.startswith("guild_only.") for qualname in qualnames):
+            contexts = [0]
+        elif any(qualname.startswith("dm_only.") for qualname in qualnames):
+            contexts = [1]
+        else:
+            contexts = [0, 1]
+
+        entry = {
+            "type": 1,
+            "name": command.name,
+            "description": description,
+            "contexts": contexts,
+        }
+        if options:
+            entry["options"] = options
+
+        payload.append(entry)
+
+    return payload
+
+
+async def create_paginator(bot: ModMail, ctx: Context, pages: list[Embed]) -> None:
     if len(pages) == 1:
         embed = pages[0]
-        embed.set_footer(discord.Embed.Empty)
+        embed.set_footer()
         await ctx.send(embed)
         return
 
@@ -75,7 +144,7 @@ async def create_paginator(bot, ctx, pages):
     await bot.state.sadd("reaction_menu_keys", f"reaction_menu:{msg.channel.id}:{msg.id}")
 
 
-async def select_guild(bot, message, msg):
+async def select_guild(bot: ModMail, message: Message, msg: Message) -> None:
     guilds = {}
 
     user_guilds = await get_user_guilds(bot, message.author)
@@ -163,7 +232,9 @@ async def select_guild(bot, message, msg):
     await bot.state.sadd("reaction_menu_keys", f"reaction_menu:{msg.channel.id}:{msg.id}")
 
 
-async def get_reaction_menu(bot, payload, kind):
+async def get_reaction_menu(
+    bot: ModMail, payload: discord.RawReactionActionEvent, kind: str
+) -> tuple[dict[str, Any], DMChannel, Message] | tuple[None, None, None]:
     menu = await bot.state.get(f"reaction_menu:{payload.channel_id}:{payload.message_id}")
     if menu and menu["kind"] == kind:
         channel = create_fake_channel(bot, payload.channel_id)
@@ -174,7 +245,7 @@ async def get_reaction_menu(bot, payload, kind):
     return None, None, None
 
 
-async def get_data(bot, guild):
+async def get_data(bot: ModMail, guild: int) -> Any:
     async with bot.pool.acquire() as conn:
         res = await conn.fetchrow("SELECT * FROM data WHERE guild=$1", guild)
         if res:
@@ -200,7 +271,7 @@ async def get_data(bot, guild):
         )
 
 
-async def get_guild_prefix(bot, guild):
+async def get_guild_prefix(bot: ModMail, guild: Guild | None) -> str | None:
     if not guild:
         return bot.config.DEFAULT_PREFIX
 
@@ -221,12 +292,12 @@ async def get_guild_prefix(bot, guild):
     return bot.config.DEFAULT_PREFIX
 
 
-async def get_user_settings(bot, user):
+async def get_user_settings(bot: ModMail, user: int) -> Any:
     async with bot.pool.acquire() as conn:
         return await conn.fetchrow("SELECT confirmation FROM account WHERE identifier=$1", user)
 
 
-async def get_user_guilds(bot, member):
+async def get_user_guilds(bot: ModMail, member: discord.abc.Snowflake) -> list[int] | None:
     user_guilds = await bot.state.get(f"user_guilds:{member.id}")
     if user_guilds is not None:
         return [int(guild) for guild in user_guilds]
@@ -285,8 +356,8 @@ async def get_user_guilds(bot, member):
     return [int(guild) for guild in guilds]
 
 
-async def get_premium_slots(bot, user):
-    if str(user) in bot.config.OWNER_USERS.split(",") + bot.config.ADMIN_USERS.split(","):
+async def get_premium_slots(bot: ModMail, user: int) -> int:
+    if str(user) in (bot.config.OWNER_USERS or "").split(",") + (bot.config.ADMIN_USERS or "").split(","):
         return 1000
 
     guild = await bot.get_guild(int(bot.config.MAIN_SERVER))
@@ -309,7 +380,7 @@ async def get_premium_slots(bot, user):
     return 0
 
 
-async def remove_premium(bot, guild):
+async def remove_premium(bot: ModMail, guild: int) -> None:
     async with bot.pool.acquire() as conn:
         await conn.execute(
             "UPDATE data SET welcome=$1, goodbye=$2, loggingplus=$3, aiprompt=$4 WHERE guild=$5",
@@ -322,15 +393,15 @@ async def remove_premium(bot, guild):
         await conn.execute("DELETE FROM snippet WHERE guild=$1", guild)
 
 
-async def is_user_banned(bot, user):
+async def is_user_banned(bot: ModMail, user: discord.abc.Snowflake) -> bool:
     return await bot.state.sismember("banned_users", user.id)
 
 
-async def is_guild_banned(bot, guild):
+async def is_guild_banned(bot: ModMail, guild: discord.abc.Snowflake) -> bool:
     return await bot.state.sismember("banned_guilds", guild.id)
 
 
-def is_modmail_channel(channel, user_id=None):
+def is_modmail_channel(channel: Any, user_id: int | str | None = None) -> bool:
     if not getattr(channel, "topic", None) or not channel.topic.startswith("ModMail Channel "):
         return False
 
@@ -344,19 +415,19 @@ def is_modmail_channel(channel, user_id=None):
     return True
 
 
-def get_modmail_user(channel):
+def get_modmail_user(channel: TextChannel) -> User:
     return create_fake_user(channel.topic.replace("ModMail Channel ", "").split(" ")[0])
 
 
-def get_modmail_channel(bot, channel):
+def get_modmail_channel(bot: ModMail, channel: TextChannel) -> DMChannel:
     return create_fake_channel(bot, channel.topic.replace("ModMail Channel ", "").split(" ")[1])
 
 
-def perm_format(perm):
+def perm_format(perm: str) -> str:
     return perm.replace("_", " ").replace("guild", "server").title()
 
 
-def tag_format(message, author):
+def tag_format(message: str, author: Any) -> str:
     tags = {
         "{username}": author.name,
         "{userid}": str(author.id),

--- a/utils/tools.py
+++ b/utils/tools.py
@@ -357,7 +357,9 @@ async def get_user_guilds(bot: ModMail, member: discord.abc.Snowflake) -> list[i
 
 
 async def get_premium_slots(bot: ModMail, user: int) -> int:
-    if str(user) in (bot.config.OWNER_USERS or "").split(",") + (bot.config.ADMIN_USERS or "").split(","):
+    if str(user) in (bot.config.OWNER_USERS or "").split(",") + (
+        bot.config.ADMIN_USERS or ""
+    ).split(","):
         return 1000
 
     guild = await bot.get_guild(int(bot.config.MAIN_SERVER))

--- a/worker.py
+++ b/worker.py
@@ -46,4 +46,11 @@ async def on_message(_):
     pass
 
 
-loop.run_until_complete(bot.start())
+async def main():
+    async with bot:
+        await bot.start()
+
+try:
+    loop.run_until_complete(main())
+except KeyboardInterrupt:
+    pass

--- a/worker.py
+++ b/worker.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 import sys
 
+from typing import Any
+
 from classes.bot import ModMail
+from classes.message import Message
 from utils import tools
 from utils.config import Config
 
@@ -23,7 +28,7 @@ logger.addHandler(handler)
 log = logging.getLogger(__name__)
 
 
-async def command_prefix(bot2, message):
+async def command_prefix(bot2: ModMail, message: Message) -> list[str | None]:
     prefix = await tools.get_guild_prefix(bot2, message.guild)
     return [f"<@{bot.id}> ", f"<@!{bot.id}> ", prefix]
 
@@ -42,13 +47,14 @@ bot = ModMail(
 
 
 @bot.event
-async def on_message(_):
+async def on_message(_: Any) -> None:
     pass
 
 
-async def main():
+async def main() -> None:
     async with bot:
         await bot.start()
+
 
 try:
     loop.run_until_complete(main())


### PR DESCRIPTION
Migrates repo to discord.py 2.7.1 and brings support for slash commands

Open Questions to resolve:
- Do we want to continue supporting prefix based commands?
    - if yes, do we want to dynamically add a "use the slash commands, this feature will be deprecated in the future warning"?
    - We can also support some prefix based commands, but have config related ones go to slash commands
- Do we want to remove the help menu - since commands can be seen in the `/` menu, it seems less relevant now than it did in v1 d.py
- how to handle admin/owner commands visibility
    - The most we can do is hide those slash commands in every server except for the modmail support server (or make a separate dev server)
- Can we change commands from `viewpremium` and `premium status` to `/premium view` and `/premium status` as subcommands or do you want to keep all of the original names?
- Do we want to use other discord functionality (modals, forms, popups, etc)?
    - If we can dynamically get a user's servers, there might be a way to utilize that when users have confirmation on or use `/new`, we can provide them a list of valid servers to send messages to instead of having them have to find the server ID.